### PR TITLE
Resource binding and texture resampling

### DIFF
--- a/src/graphics/pipeline/resampling.rs
+++ b/src/graphics/pipeline/resampling.rs
@@ -2,13 +2,14 @@ use std::marker::PhantomData;
 
 use wgpu::{BlendState, ColorTargetState, ColorWrites, TextureFormat};
 
-use super::{triangle_primitive, PipelineState};
+use super::{triangle_primitive, Binding, PipelineState};
 use crate::graphics::resources::vertex::ImageVertex;
 
-pub fn state<'a>(color_format: TextureFormat) -> PipelineState<'a, ImageVertex> {
+pub fn state(color_format: TextureFormat, binding: &Binding) -> PipelineState<ImageVertex> {
     PipelineState {
         name: "Resampling",
         shader_code: include_str!("shaders/resampling.wgsl"),
+        bindings: vec![binding],
         color_target: color_target(color_format),
         depth_stencil: None,
         primitive: triangle_primitive(),

--- a/src/graphics/pipeline/shaders/resampling.wgsl
+++ b/src/graphics/pipeline/shaders/resampling.wgsl
@@ -1,3 +1,8 @@
+@group(0) @binding(0)
+var source_texture: texture_2d<f32>;
+@group(0) @binding(1)
+var linear_sampler: sampler;
+
 struct VertexInput {
     @location(0) canon: vec2f,
     @location(1) uv: vec2f,
@@ -5,18 +10,15 @@ struct VertexInput {
 
 struct FragmentInput {
     @builtin(position) clip_position: vec4f,
-    @location(0) color: vec4f,
+    @location(0) uv: vec2f,
 };
 
 @vertex
 fn vertex(in: VertexInput) -> FragmentInput {
-    return FragmentInput(
-        vec4f(in.canon, 0., 1.),
-        vec4f((in.canon + 1.) / 2, 1., 1.)
-    );
+    return FragmentInput(vec4f(in.canon, 0., 1.), in.uv);
 }
 
 @fragment
 fn fragment(in: FragmentInput) -> @location(0) vec4f {
-    return in.color;
+    return textureSample(source_texture, linear_sampler, in.uv);
 }

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -2,15 +2,20 @@ use wgpu::Buffer;
 
 use super::{Client, Image};
 
-pub use texture::{Texture, COLOR_FORMAT};
+pub use {
+    binding::Binding,
+    texture::{Texture, COLOR_FORMAT},
+};
 
+mod binding;
 mod buffer;
 mod texture;
 pub mod vertex;
 
 pub struct Resources {
-    #[allow(unused)]
-    pub source_texture: Texture,
+    pub binding: Binding,
+
+    pub _source_texture: Texture,
     pub multisampled_texture: Texture,
     pub target_texture: Texture,
 
@@ -21,12 +26,15 @@ pub struct Resources {
 impl Resources {
     pub fn new(image: &Image, client: &Client) -> Self {
         let target_texture = Texture::new_target(client);
+        let _source_texture = Texture::new_source(image, client);
 
         Self {
+            binding: Binding::new(&_source_texture, &client.device),
+
             image_vertex_buffer: buffer::create_image_vertex_buffer(&client.device),
             transfer_buffer: buffer::create_transfer_buffer(&target_texture, &client.device),
 
-            source_texture: Texture::new_source(image, client),
+            _source_texture,
             multisampled_texture: Texture::new_multisampled(client),
             target_texture,
         }

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -15,6 +15,7 @@ pub mod vertex;
 pub struct Resources {
     pub binding: Binding,
 
+    /// This texture handler is stored to keep the allocation, but it is not used after being declared.
     pub _source_texture: Texture,
     pub multisampled_texture: Texture,
     pub target_texture: Texture,

--- a/src/graphics/resources/binding.rs
+++ b/src/graphics/resources/binding.rs
@@ -48,7 +48,7 @@ fn create_bind_group(entries: Vec<Entry>, layout: &BindGroupLayout, device: &Dev
     let entries: Vec<BindGroupEntry> = entries
         .into_iter()
         .enumerate()
-        .map(|(i, entry)| wgpu::BindGroupEntry {
+        .map(|(i, entry)| BindGroupEntry {
             binding: i as u32,
             resource: entry.resource,
         })
@@ -64,18 +64,13 @@ fn create_bind_group(entries: Vec<Entry>, layout: &BindGroupLayout, device: &Dev
 fn create_layout(entries: &[Entry], device: &Device) -> BindGroupLayout {
     use wgpu::{BindGroupLayoutDescriptor, BindGroupLayoutEntry};
 
-    let entries: Vec<BindGroupLayoutEntry> = entries
-        .iter()
-        .enumerate()
-        .map(|(i, entry)| {
-            BindGroupLayoutEntry {
-                binding: i as u32,
-                visibility: entry.stage,
-                ty: entry.binding_type,
-                count: None, // For arrays
-            }
-        })
-        .collect();
+    let entry = |(i, entry): (usize, &Entry)| BindGroupLayoutEntry {
+        binding: i as u32,
+        visibility: entry.stage,
+        ty: entry.binding_type,
+        count: None, // For arrays
+    };
+    let entries: Vec<BindGroupLayoutEntry> = entries.iter().enumerate().map(entry).collect();
 
     device.create_bind_group_layout(&BindGroupLayoutDescriptor {
         label: label!("BindingLayout"),

--- a/src/graphics/resources/binding.rs
+++ b/src/graphics/resources/binding.rs
@@ -1,0 +1,94 @@
+use wgpu::{BindGroup, BindGroupLayout, BindingResource, BindingType, Device, ShaderStages};
+
+use super::Texture;
+
+struct Entry<'a> {
+    stage: ShaderStages,
+    binding_type: BindingType,
+    resource: BindingResource<'a>,
+}
+
+pub struct Binding {
+    pub group: BindGroup,
+    pub layout: BindGroupLayout,
+}
+
+impl Binding {
+    pub fn new(source_texture: &Texture, device: &Device) -> Self {
+        let sampler = create_sampler(device);
+
+        let entries = vec![
+            Entry {
+                stage: ShaderStages::FRAGMENT,
+                binding_type: BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                resource: BindingResource::TextureView(&source_texture.view),
+            },
+            Entry {
+                stage: ShaderStages::FRAGMENT,
+                binding_type: BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                resource: BindingResource::Sampler(&sampler),
+            },
+        ];
+        let layout = create_layout(&entries, device);
+
+        Self {
+            group: create_bind_group(entries, &layout, device),
+            layout,
+        }
+    }
+}
+
+fn create_bind_group(entries: Vec<Entry>, layout: &BindGroupLayout, device: &Device) -> BindGroup {
+    use wgpu::BindGroupEntry;
+
+    let entries: Vec<BindGroupEntry> = entries
+        .into_iter()
+        .enumerate()
+        .map(|(i, entry)| wgpu::BindGroupEntry {
+            binding: i as u32,
+            resource: entry.resource,
+        })
+        .collect();
+
+    device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: label!("BindingGroup"),
+        layout,
+        entries: &entries,
+    })
+}
+
+fn create_layout(entries: &[Entry], device: &Device) -> BindGroupLayout {
+    use wgpu::{BindGroupLayoutDescriptor, BindGroupLayoutEntry};
+
+    let entries: Vec<BindGroupLayoutEntry> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            BindGroupLayoutEntry {
+                binding: i as u32,
+                visibility: entry.stage,
+                ty: entry.binding_type,
+                count: None, // For arrays
+            }
+        })
+        .collect();
+
+    device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        label: label!("BindingLayout"),
+        entries: &entries,
+    })
+}
+
+fn create_sampler(device: &Device) -> wgpu::Sampler {
+    use wgpu::FilterMode;
+
+    device.create_sampler(&wgpu::SamplerDescriptor {
+        mag_filter: FilterMode::Linear,
+        min_filter: FilterMode::Linear,
+        ..Default::default()
+    })
+}

--- a/src/graphics/resources/buffer.rs
+++ b/src/graphics/resources/buffer.rs
@@ -19,12 +19,12 @@ fn quad_vertices() -> [ImageVertex; 6] {
         uv: vec2(u, v),
     };
     [
-        vertex(1., 1., 1., 1.),
-        vertex(1., -1., 1., 0.),
-        vertex(-1., -1., 0., 0.),
-        vertex(1., 1., 1., 1.),
-        vertex(-1., -1., 1., 0.),
-        vertex(-1., 1., 0., 1.),
+        vertex(1., 1., 1., 0.),
+        vertex(1., -1., 1., 1.),
+        vertex(-1., -1., 0., 1.),
+        vertex(1., 1., 1., 0.),
+        vertex(-1., -1., 0., 1.),
+        vertex(-1., 1., 0., 0.),
     ]
 }
 

--- a/src/graphics/workload/render.rs
+++ b/src/graphics/workload/render.rs
@@ -6,6 +6,8 @@ impl Context {
     pub(super) fn render(&self, command_encoder: &mut CommandEncoder) {
         let mut pass = render_pass(&self.res, command_encoder);
 
+        pass.set_bind_group(0, &self.res.binding.group, &[]);
+
         pass.set_pipeline(&self.pipelines.resampling);
         pass.set_vertex_buffer(0, self.res.image_vertex_buffer.slice(..));
         pass.draw(0..6, 0..1);


### PR DESCRIPTION
- Fixed wrong UVs in the vertex buffer
- Ported `binding.rs`, added a sampler
- Changed the shader

The program now acts as a rescaler, a source image of any size is inserted and is "stretched" to the requested size. The image is scaled using hardware bilinear interpolation.

![image](https://github.com/nilgoyette/diffusion-slice-rs/assets/16839118/881ad955-6be4-478f-9f2a-4ca3fa7d5f84)