### PR TITLE
Keep aspect stretch mode

### DIFF
--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -1,3 +1,4 @@
+use glam::UVec2;
 use wgpu::{Adapter, Device, Queue};
 
 use super::UserInputs;
@@ -7,7 +8,7 @@ use crate::graphics::resources::COLOR_FORMAT;
 pub struct Client {
     pub device: Device,
     pub command_queue: Queue,
-    pub img_size: (u32, u32),
+    pub img_size: UVec2,
     pub multisample_count: u32,
 }
 
@@ -40,9 +41,8 @@ fn max_multisample_count(adapter: &Adapter) -> u32 {
 async fn device(adapter: &Adapter) -> (Device, Queue) {
     use wgpu::Features;
 
-    let required_features = Features::POLYGON_MODE_LINE
-        | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-        | Features::ADDRESS_MODE_CLAMP_TO_BORDER;
+    let required_features =
+        Features::POLYGON_MODE_LINE | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
 
     let desc = &wgpu::DeviceDescriptor {
         label: None,

--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -40,8 +40,9 @@ fn max_multisample_count(adapter: &Adapter) -> u32 {
 async fn device(adapter: &Adapter) -> (Device, Queue) {
     use wgpu::Features;
 
-    let required_features =
-        Features::POLYGON_MODE_LINE | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+    let required_features = Features::POLYGON_MODE_LINE
+        | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+        | Features::ADDRESS_MODE_CLAMP_TO_BORDER;
 
     let desc = &wgpu::DeviceDescriptor {
         label: None,

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -1,3 +1,4 @@
+use glam::UVec2;
 use wgpu::Buffer;
 
 use super::{Client, Image};
@@ -15,7 +16,6 @@ pub mod vertex;
 pub struct Resources {
     pub binding: Binding,
 
-    pub _source_texture: Texture,
     pub multisampled_texture: Texture,
     pub target_texture: Texture,
 
@@ -26,15 +26,16 @@ pub struct Resources {
 impl Resources {
     pub fn new(image: &Image, client: &Client) -> Self {
         let target_texture = Texture::new_target(client);
-        let _source_texture = Texture::new_source(image, client);
+        let source_texture = Texture::new_source(image, client);
+
+        let img_size = UVec2::from(image.dimensions());
 
         Self {
-            binding: Binding::new(&_source_texture, &client.device),
+            binding: Binding::new(&source_texture, &client.device),
 
-            image_vertex_buffer: buffer::create_image_vertex_buffer(image.dimensions(), &client),
+            image_vertex_buffer: buffer::create_image_vertex_buffer(img_size, client),
             transfer_buffer: buffer::create_transfer_buffer(&target_texture, &client.device),
 
-            _source_texture,
             multisampled_texture: Texture::new_multisampled(client),
             target_texture,
         }

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -31,7 +31,7 @@ impl Resources {
         Self {
             binding: Binding::new(&_source_texture, &client.device),
 
-            image_vertex_buffer: buffer::create_image_vertex_buffer(&client.device),
+            image_vertex_buffer: buffer::create_image_vertex_buffer(image.dimensions(), &client),
             transfer_buffer: buffer::create_transfer_buffer(&target_texture, &client.device),
 
             _source_texture,

--- a/src/graphics/resources/binding.rs
+++ b/src/graphics/resources/binding.rs
@@ -79,11 +79,14 @@ fn create_layout(entries: &[Entry], device: &Device) -> BindGroupLayout {
 }
 
 fn create_sampler(device: &Device) -> wgpu::Sampler {
-    use wgpu::FilterMode;
+    use wgpu::{AddressMode, FilterMode};
 
     device.create_sampler(&wgpu::SamplerDescriptor {
+        address_mode_u: AddressMode::ClampToBorder,
+        address_mode_v: AddressMode::ClampToBorder,
         mag_filter: FilterMode::Linear,
         min_filter: FilterMode::Linear,
+        border_color: Some(wgpu::SamplerBorderColor::OpaqueBlack),
         ..Default::default()
     })
 }

--- a/src/graphics/resources/binding.rs
+++ b/src/graphics/resources/binding.rs
@@ -82,11 +82,10 @@ fn create_sampler(device: &Device) -> wgpu::Sampler {
     use wgpu::{AddressMode, FilterMode};
 
     device.create_sampler(&wgpu::SamplerDescriptor {
-        address_mode_u: AddressMode::ClampToBorder,
-        address_mode_v: AddressMode::ClampToBorder,
+        address_mode_u: AddressMode::ClampToEdge,
+        address_mode_v: AddressMode::ClampToEdge,
         mag_filter: FilterMode::Linear,
         min_filter: FilterMode::Linear,
-        border_color: Some(wgpu::SamplerBorderColor::OpaqueBlack),
         ..Default::default()
     })
 }

--- a/src/graphics/resources/buffer.rs
+++ b/src/graphics/resources/buffer.rs
@@ -1,43 +1,49 @@
-use glam::vec2;
+use glam::{vec2, UVec2, Vec2};
 use wgpu::{Buffer, BufferUsages, Device};
 
 use super::{vertex::ImageVertex, Client, Texture};
 
-pub fn create_image_vertex_buffer(size: (u32, u32), client: &Client) -> Buffer {
+pub fn create_image_vertex_buffer(size: UVec2, client: &Client) -> Buffer {
     use wgpu::util::{BufferInitDescriptor, DeviceExt};
+
+    let uv_offset = uv_offset(size, client.img_size);
 
     client.device.create_buffer_init(&BufferInitDescriptor {
         label: label!("ImageVertexBuffer"),
-        contents: bytemuck::cast_slice(&quad_vertices(size, client.img_size)),
+        contents: bytemuck::cast_slice(&quad_vertices(uv_offset)),
         usage: BufferUsages::VERTEX,
     })
 }
 
-fn quad_vertices(src_size: (u32, u32), dst_size: (u32, u32)) -> [ImageVertex; 6] {
-    let (src_w, src_h, dst_w, dst_h) = {
-        let ((src_w, src_h), (dst_w, dst_h)) = (src_size, dst_size);
-        (src_w as f32, src_h as f32, dst_w as f32, dst_h as f32)
-    };
-    let (a, b) = (dst_w / src_w, dst_h / src_h);
+/// Calculates the UV offset needed to maintain the source image's aspect ratio
+fn uv_offset(src_size: UVec2, dst_size: UVec2) -> Vec2 {
+    let (src_size, dst_size) = (src_size.as_vec2(), dst_size.as_vec2());
 
-    let (du, dv) = if a > b {
-        let c = src_w * b;
-        ((dst_w - c) / (2. * c), 0.)
+    let ratio = dst_size / src_size;
+
+    if ratio.x > ratio.y {
+        let img_w = src_size.x * ratio.y;
+        vec2((dst_size.x - img_w) / (2. * img_w), 0.)
     } else {
-        let c = src_h * a;
-        (0., (dst_h - c) / (2. * c))
-    };
-    let vertex = |x, y, uv| ImageVertex {
+        let img_h = src_size.y * ratio.x;
+        vec2(0., (dst_size.y - img_h) / (2. * img_h))
+    }
+}
+
+fn quad_vertices(uv_offset: Vec2) -> [ImageVertex; 6] {
+    let (du, dv) = (uv_offset.x, uv_offset.y);
+
+    let vertex = |x, y, u, v| ImageVertex {
         canon: vec2(x, y),
-        uv,
+        uv: vec2(u, v),
     };
     [
-        vertex(1., 1., vec2(1. + du, 0. - dv)),
-        vertex(1., -1., vec2(1. + du, 1. + dv)),
-        vertex(-1., -1., vec2(0. - du, 1. + dv)),
-        vertex(1., 1., vec2(1. + du, 0. - dv)),
-        vertex(-1., -1., vec2(0. - du, 1. + dv)),
-        vertex(-1., 1., vec2(0. - du, 0. - dv)),
+        vertex(1., 1., 1. + du, 0. - dv),
+        vertex(1., -1., 1. + du, 1. + dv),
+        vertex(-1., -1., 0. - du, 1. + dv),
+        vertex(1., 1., 1. + du, 0. - dv),
+        vertex(-1., -1., 0. - du, 1. + dv),
+        vertex(-1., 1., 0. - du, 0. - dv),
     ]
 }
 

--- a/src/graphics/resources/buffer.rs
+++ b/src/graphics/resources/buffer.rs
@@ -1,30 +1,43 @@
 use glam::vec2;
 use wgpu::{Buffer, BufferUsages, Device};
 
-use super::{vertex::ImageVertex, Texture};
+use super::{vertex::ImageVertex, Client, Texture};
 
-pub fn create_image_vertex_buffer(device: &Device) -> Buffer {
+pub fn create_image_vertex_buffer(size: (u32, u32), client: &Client) -> Buffer {
     use wgpu::util::{BufferInitDescriptor, DeviceExt};
 
-    device.create_buffer_init(&BufferInitDescriptor {
+    client.device.create_buffer_init(&BufferInitDescriptor {
         label: label!("ImageVertexBuffer"),
-        contents: bytemuck::cast_slice(&quad_vertices()),
+        contents: bytemuck::cast_slice(&quad_vertices(size, client.img_size)),
         usage: BufferUsages::VERTEX,
     })
 }
 
-fn quad_vertices() -> [ImageVertex; 6] {
-    let vertex = |x, y, u, v| ImageVertex {
+fn quad_vertices(src_size: (u32, u32), dst_size: (u32, u32)) -> [ImageVertex; 6] {
+    let (src_w, src_h, dst_w, dst_h) = {
+        let ((src_w, src_h), (dst_w, dst_h)) = (src_size, dst_size);
+        (src_w as f32, src_h as f32, dst_w as f32, dst_h as f32)
+    };
+    let (a, b) = (dst_w / src_w, dst_h / src_h);
+
+    let (du, dv) = if a > b {
+        let c = src_w * b;
+        ((dst_w - c) / (2. * c), 0.)
+    } else {
+        let c = src_h * a;
+        (0., (dst_h - c) / (2. * c))
+    };
+    let vertex = |x, y, uv| ImageVertex {
         canon: vec2(x, y),
-        uv: vec2(u, v),
+        uv,
     };
     [
-        vertex(1., 1., 1., 0.),
-        vertex(1., -1., 1., 1.),
-        vertex(-1., -1., 0., 1.),
-        vertex(1., 1., 1., 0.),
-        vertex(-1., -1., 0., 1.),
-        vertex(-1., 1., 0., 0.),
+        vertex(1., 1., vec2(1. + du, 0. - dv)),
+        vertex(1., -1., vec2(1. + du, 1. + dv)),
+        vertex(-1., -1., vec2(0. - du, 1. + dv)),
+        vertex(1., 1., vec2(1. + du, 0. - dv)),
+        vertex(-1., -1., vec2(0. - du, 1. + dv)),
+        vertex(-1., 1., vec2(0. - du, 0. - dv)),
     ]
 }
 

--- a/src/graphics/resources/texture.rs
+++ b/src/graphics/resources/texture.rs
@@ -43,7 +43,7 @@ impl Texture {
 
     pub fn new_source(image: &Image, client: &Client) -> Self {
         let cfg = TextureConfig {
-            name: "SourceTexture".to_string(),
+            name: "Source".to_string(),
             usage: TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
             format: COLOR_FORMAT,
             size: extent(image.dimensions()),
@@ -58,7 +58,7 @@ impl Texture {
 
     pub fn new_multisampled(client: &Client) -> Self {
         let cfg = TextureConfig {
-            name: "MultisampledTexture".to_string(),
+            name: "Multisampled".to_string(),
             usage: TextureUsages::RENDER_ATTACHMENT,
             format: COLOR_FORMAT,
             size: extent(client.img_size),
@@ -70,7 +70,7 @@ impl Texture {
 
     pub fn new_target(client: &Client) -> Self {
         let cfg = TextureConfig {
-            name: "TargetTexture".to_string(),
+            name: "Target".to_string(),
             usage: TextureUsages::COPY_SRC | TextureUsages::RENDER_ATTACHMENT,
             format: COLOR_FORMAT,
             size: extent(client.img_size),
@@ -145,7 +145,7 @@ impl Client {
             1
         };
         self.device.create_texture(&wgpu::TextureDescriptor {
-            label: label!("{:?}Texture", cfg.name),
+            label: label!("{}Texture", cfg.name),
             size: cfg.size,
             mip_level_count: 1,
             sample_count,

--- a/src/graphics/resources/texture.rs
+++ b/src/graphics/resources/texture.rs
@@ -1,3 +1,4 @@
+use glam::UVec2;
 use wgpu::{Extent3d, ImageCopyTexture, ImageDataLayout, Queue, TextureFormat, TextureUsages};
 
 use crate::graphics::{Client, Image};
@@ -46,7 +47,7 @@ impl Texture {
             name: "Source".to_string(),
             usage: TextureUsages::COPY_DST | TextureUsages::TEXTURE_BINDING,
             format: COLOR_FORMAT,
-            size: extent(image.dimensions()),
+            size: extent(UVec2::from(image.dimensions())),
             multisampled: false,
             pad_bytes_per_row: false,
         };
@@ -124,11 +125,10 @@ fn bytes_layout(cfg: &TextureConfig) -> (u32, u32) {
     }
 }
 
-fn extent(size: (u32, u32)) -> Extent3d {
-    let (width, height) = size;
+fn extent(size: UVec2) -> Extent3d {
     wgpu::Extent3d {
-        width,
-        height,
+        width: size.x,
+        height: size.y,
         depth_or_array_layers: 1,
     }
 }

--- a/src/graphics/workload.rs
+++ b/src/graphics/workload.rs
@@ -14,9 +14,9 @@ impl Context {
 
         self.client.command_queue.submit([command_encoder.finish()]);
 
-        let (width, height) = self.client.img_size;
+        let size = self.client.img_size;
 
-        Image::from_raw(width, height, self.receive_image_bytes())
+        Image::from_raw(size.x, size.y, self.receive_image_bytes())
             .expect("Data size must match image dimensions")
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use std::{
     time::Instant,
 };
 
+use glam::{uvec2, UVec2};
+
 mod file;
 mod graphics;
 
@@ -10,7 +12,7 @@ type Image = image::RgbaImage;
 
 pub struct UserInputs {
     pub src_img: Image,
-    pub dst_img_size: (u32, u32),
+    pub dst_img_size: UVec2,
     pub dst_img_path: PathBuf,
 }
 
@@ -23,7 +25,7 @@ fn main() {
     // TODO Validate user inputs
     let inputs = UserInputs {
         src_img: file::load_image(Path::new("sunshine.jpg")),
-        dst_img_size: (800, 600),
+        dst_img_size: uvec2(1200, 800),
         dst_img_path: PathBuf::from("output.png"),
     };
     let image = graphics::run_full_pipeline(&inputs);


### PR DESCRIPTION
- Added UV offset to modify the image stretching mode.
- Changed size type from `(u32, u32)` to `glam::UVec2` in all places.
- Fixed an oversight with texture labels.
- Removed the unused field `source_texture`. After the last commit, I noticed that resources stay allocated on the GPU when there's a binding using them, so we don't need to save it after all.

![output](https://github.com/nilgoyette/diffusion-slice-rs/assets/16839118/40805b4e-4813-4e9b-9774-47b61ee7ddfa)

I used `AddressMode::ClampToEdge` assuming our images will have constant colors around edges. This will simply fill the padding with the background color. If that's not the case here's the alternatives:

- `AddressMode::ClampToBorder` allows us the fill the padding with pure white or pure black.
- Fill the padding with a manually specified clear color, which requires offsetting the canonical positions instead of the UVs.