### PR TITLE
Nifti image support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wgpu = "0.20" # GPU API
-env_logger = "0.11" # Logging client
-log = "0.4" # Logging API
-pollster = "0.3" # Async runtime
 bytemuck = { version = "1.16", features = ["derive"] } # Raw data manipulations
+clap = { version = "4.5.8", features = ["derive"] }
+env_logger = "0.11" # Logging client
 glam = { version = "0.27", features = ["bytemuck"] } # Fast math types
 image = "0.25" # Image encoders/decoders 
-clap = { version = "4.5.8", features = ["derive"] }
+log = "0.4" # Logging API
+ndarray = "0.15"
+nifti = { version = "0.16", features = ["ndarray_volumes", "nalgebra_affine"] }
+pollster = "0.3" # Async runtime
+wgpu = "0.20" # GPU API

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ pollster = "0.3" # Async runtime
 bytemuck = { version = "1.16", features = ["derive"] } # Raw data manipulations
 glam = { version = "0.27", features = ["bytemuck"] } # Fast math types
 image = "0.25" # Image encoders/decoders 
+clap = { version = "4.5.8", features = ["derive"] }

--- a/src/file.rs
+++ b/src/file.rs
@@ -5,7 +5,7 @@ use nifti::{DataElement, InMemNiftiVolume, IntoNdArray, NiftiHeader, NiftiObject
 
 use crate::Image;
 
-/// Read a nifti image into a `Array3<T>` object.
+/// Read a NIfTI image into a `Array3<T>` object.
 ///
 /// Panics if the image isn't in 3D.
 pub fn read_3d_image<P, T>(path: P) -> (NiftiHeader, Array3<T>)
@@ -21,11 +21,11 @@ where
     let nifti_object = ReaderOptions::new()
         .fix_header(true)
         .read_file(path)
-        .expect("Nifti file is unreadable.");
+        .expect("NIfTI file is unreadable.");
     let mut header = nifti_object.header().clone();
     let mut volume = nifti_object.into_volume();
 
-    // Fix wrong dimension on some 3D images and check if the requested dimension is equal to
+    // Fix wrong dimensions on some 3D images and check if the requested dimension is equal to
     // the actual number of dimensions of the image.
     if header.dim[header.dim[0] as usize] == 1 {
         header.dim[0] -= 1;

--- a/src/file.rs
+++ b/src/file.rs
@@ -21,7 +21,7 @@ where
     let nifti_object = ReaderOptions::new()
         .fix_header(true)
         .read_file(path)
-        .expect("NIfTI file is unreadable.");
+        .expect("NIfTI file should be readable and valid.");
     let mut header = nifti_object.header().clone();
     let mut volume = nifti_object.into_volume();
 
@@ -35,7 +35,7 @@ where
     let dyn_data = volume.into_ndarray::<T>().unwrap();
     let data = dyn_data
         .into_dimensionality::<Ix3>()
-        .expect("Loaded mask in not a 3D image");
+        .expect("Loaded NIfTI image should be a 3D array");
     (header, data)
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,4 +1,4 @@
-use crate::{Image, UserInputs};
+use crate::{Image, ImageSlice, UserInputs};
 use {client::Client, pipeline::Pipelines, resources::Resources};
 
 #[macro_use]

--- a/src/graphics/pipeline/shaders/resampling.wgsl
+++ b/src/graphics/pipeline/shaders/resampling.wgsl
@@ -20,5 +20,6 @@ fn vertex(in: VertexInput) -> FragmentInput {
 
 @fragment
 fn fragment(in: FragmentInput) -> @location(0) vec4f {
-    return textureSample(source_texture, linear_sampler, in.uv);
+    let value = textureSample(source_texture, linear_sampler, in.uv).r;
+    return vec4f(vec3f(value), 1.);
 }

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -1,7 +1,7 @@
 use glam::UVec2;
 use wgpu::Buffer;
 
-use super::{Client, Image};
+use super::{Client, ImageSlice};
 
 pub use {
     binding::Binding,
@@ -24,11 +24,11 @@ pub struct Resources {
 }
 
 impl Resources {
-    pub fn new(image: &Image, client: &Client) -> Self {
+    pub fn new(image: &ImageSlice, client: &Client) -> Self {
         let target_texture = Texture::new_target(client);
         let source_texture = Texture::new_source(image, client);
 
-        let img_size = UVec2::from(image.dimensions());
+        let img_size = UVec2::new(image.dim().0 as u32, image.dim().1 as u32);
 
         Self {
             binding: Binding::new(&source_texture, &client.device),

--- a/src/graphics/resources/buffer.rs
+++ b/src/graphics/resources/buffer.rs
@@ -38,12 +38,12 @@ fn quad_vertices(uv_offset: Vec2) -> [ImageVertex; 6] {
         uv: vec2(u, v),
     };
     [
-        vertex(1., 1., 1. + du, 0. - dv),
-        vertex(1., -1., 1. + du, 1. + dv),
-        vertex(-1., -1., 0. - du, 1. + dv),
-        vertex(1., 1., 1. + du, 0. - dv),
-        vertex(-1., -1., 0. - du, 1. + dv),
-        vertex(-1., 1., 0. - du, 0. - dv),
+        vertex(1., 1., 0. - du, 1. + dv),
+        vertex(1., -1., 0. - du, 0. - dv),
+        vertex(-1., -1., 1. + du, 0. - dv),
+        vertex(1., 1., 0. - du, 1. + dv),
+        vertex(-1., -1., 1. + du, 0. - dv),
+        vertex(-1., 1., 1. + du, 1. + dv),
     ]
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ type ImageSlice = Array2<u8>;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Input NiFTI image
+    /// Input NIfTI image
     pub input_image: PathBuf,
 
     /// Output png image
@@ -40,10 +40,10 @@ fn main() {
 
     let (_nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
 
-    // Lets take a "random" slice for now
+    // Let's take a "random" slice for now
     let slice = data.slice(s![.., 90, ..]).to_owned();
 
-    // Rescale wathever we've got to u8
+    // Rescale whatever we've got to u8
     let image_min = data.fold(f32::MAX, |acc, &v| f32::min(acc, v));
     let image_max = data.fold(f32::MIN, |acc, &v| f32::max(acc, v));
     let image_range = image_max - image_min;
@@ -53,9 +53,9 @@ fn main() {
     let slice: Array2<u8> =
         slice.mapv(|v| ((v - image_min) * (type_range / image_range) + type_min) as u8);
 
-    // A NiFTI image is stored in 'f' order, but it doesn't know that much itself so ndarray thinks
+    // A NIfTI image is stored in 'f' order, but it doesn't know that much itself so ndarray thinks
     // it's the standard 'c' order. Because of this, we convert it to 'f' order, which actually
-    // converts it to 'c' order. Voila.
+    // converts it to 'c' order. Voilà.
     let mut src_img = Array2::zeros(slice.dim().f());
     src_img.assign(&slice);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,27 @@ use std::{
     time::Instant,
 };
 
+use clap::Parser;
 use glam::{uvec2, UVec2};
 
 mod file;
 mod graphics;
 
 type Image = image::RgbaImage;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Input NiFTI image
+    pub input_image: PathBuf,
+
+    /// Output png image
+    pub output: PathBuf,
+
+    /// Width and height of the output 2D image
+    #[arg(num_args(2), long, default_values = ["800", "600"])]
+    pub output_size: Vec<u32>,
+}
 
 pub struct UserInputs {
     pub src_img: Image,
@@ -19,13 +34,16 @@ pub struct UserInputs {
 fn main() {
     let start = Instant::now();
 
+    let args = Args::parse();
+    println!("{args:?}");
+
     init_logger();
 
     // TODO Make this parameterable
     // TODO Validate user inputs
     let inputs = UserInputs {
         src_img: file::load_image(Path::new("sunshine.jpg")),
-        dst_img_size: uvec2(1200, 800),
+        dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
         dst_img_path: PathBuf::from("output.png"),
     };
     let image = graphics::run_full_pipeline(&inputs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
-use std::{
-    path::{Path, PathBuf},
-    time::Instant,
-};
+use std::{path::PathBuf, time::Instant};
 
 use clap::Parser;
+use file::read_3d_image;
 use glam::{uvec2, UVec2};
+use ndarray::{s, Array2, ShapeBuilder};
 
 mod file;
 mod graphics;
 
 type Image = image::RgbaImage;
+type ImageSlice = Array2<u8>;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -26,23 +26,42 @@ struct Args {
 }
 
 pub struct UserInputs {
-    pub src_img: Image,
+    pub src_img: ImageSlice,
     pub dst_img_size: UVec2,
     pub dst_img_path: PathBuf,
 }
 
 fn main() {
     let start = Instant::now();
+    init_logger();
 
     let args = Args::parse();
     println!("{args:?}");
 
-    init_logger();
+    let (_nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
 
-    // TODO Make this parameterable
+    // Lets take a "random" slice for now
+    let slice = data.slice(s![.., 90, ..]).to_owned();
+
+    // Rescale wathever we've got to u8
+    let image_min = data.fold(f32::MAX, |acc, &v| f32::min(acc, v));
+    let image_max = data.fold(f32::MIN, |acc, &v| f32::max(acc, v));
+    let image_range = image_max - image_min;
+    let type_min = 0.0;
+    let type_max = 255.0;
+    let type_range = type_max - type_min;
+    let slice: Array2<u8> =
+        slice.mapv(|v| ((v - image_min) * (type_range / image_range) + type_min) as u8);
+
+    // A NiFTI image is stored in 'f' order, but it doesn't know that much itself so ndarray thinks
+    // it's the standard 'c' order. Because of this, we convert it to 'f' order, which actually
+    // converts it to 'c' order. Voila.
+    let mut src_img = Array2::zeros(slice.dim().f());
+    src_img.assign(&slice);
+
     // TODO Validate user inputs
     let inputs = UserInputs {
-        src_img: file::load_image(Path::new("sunshine.jpg")),
+        src_img,
         dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
         dst_img_path: PathBuf::from("output.png"),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ struct Args {
     /// Input NIfTI image
     pub input_image: PathBuf,
 
-    /// Output png image
+    /// Output folder to save all png
     pub output: PathBuf,
 
     /// Width and height of the output 2D image
@@ -28,7 +28,6 @@ struct Args {
 pub struct UserInputs {
     pub src_img: ImageSlice,
     pub dst_img_size: UVec2,
-    pub dst_img_path: PathBuf,
 }
 
 fn main() {
@@ -39,17 +38,18 @@ fn main() {
     println!("{args:?}");
 
     let (nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
-    let slicer = Slicer::from_3d(nifti_header, data, 1, View::Anterior, (0.3, 0.7));
+    let slicer = Slicer::from_3d(nifti_header, data, 3, View::Anterior, (0.3, 0.7));
     for slice in slicer.slices {
         let inputs = UserInputs {
             src_img: slice.data,
             dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
-            dst_img_path: PathBuf::from("output.png"),
         };
         let image = graphics::run_full_pipeline(&inputs);
 
-        // TODO Rename output image according to view and index
-        file::save_image(image, &inputs.dst_img_path);
+        // TODO Support a prefix, like "prefix{}_{}.png"
+        let mut write_to = args.output.clone();
+        write_to.push(format!("{}_{}.png", slice.view.name(), slice.index));
+        file::save_image(image, &write_to);
     }
 
     log::info!("Program duration: {:?}", start.elapsed());

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ use std::{path::PathBuf, time::Instant};
 use clap::Parser;
 use file::read_3d_image;
 use glam::{uvec2, UVec2};
-use ndarray::{s, Array2, ShapeBuilder};
+use slicer::{ImageSlice, Slicer, View};
 
 mod file;
 mod graphics;
+mod slicer;
 
 type Image = image::RgbaImage;
-type ImageSlice = Array2<u8>;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -38,36 +38,19 @@ fn main() {
     let args = Args::parse();
     println!("{args:?}");
 
-    let (_nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
+    let (nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
+    let slicer = Slicer::from_3d(nifti_header, data, 1, View::Anterior, (0.3, 0.7));
+    for slice in slicer.slices {
+        let inputs = UserInputs {
+            src_img: slice.data,
+            dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
+            dst_img_path: PathBuf::from("output.png"),
+        };
+        let image = graphics::run_full_pipeline(&inputs);
 
-    // Let's take a "random" slice for now
-    let slice = data.slice(s![.., 90, ..]).to_owned();
-
-    // Rescale whatever we've got to u8
-    let image_min = data.fold(f32::MAX, |acc, &v| f32::min(acc, v));
-    let image_max = data.fold(f32::MIN, |acc, &v| f32::max(acc, v));
-    let image_range = image_max - image_min;
-    let type_min = 0.0;
-    let type_max = 255.0;
-    let type_range = type_max - type_min;
-    let slice: Array2<u8> =
-        slice.mapv(|v| ((v - image_min) * (type_range / image_range) + type_min) as u8);
-
-    // A NIfTI image is stored in 'f' order, but it doesn't know that much itself so ndarray thinks
-    // it's the standard 'c' order. Because of this, we convert it to 'f' order, which actually
-    // converts it to 'c' order. Voilà.
-    let mut src_img = Array2::zeros(slice.dim().f());
-    src_img.assign(&slice);
-
-    // TODO Validate user inputs
-    let inputs = UserInputs {
-        src_img,
-        dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
-        dst_img_path: PathBuf::from("output.png"),
-    };
-    let image = graphics::run_full_pipeline(&inputs);
-
-    file::save_image(image, &inputs.dst_img_path);
+        // TODO Rename output image according to view and index
+        file::save_image(image, &inputs.dst_img_path);
+    }
 
     log::info!("Program duration: {:?}", start.elapsed());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,10 @@ struct Args {
     /// Width and height of the output 2D image
     #[arg(num_args(2), long, default_values = ["800", "600"])]
     pub output_size: Vec<u32>,
+
+    /// Which view(s) to use tp capture the image(s)
+    #[arg(num_args(1..7), long, default_values = ["superior", "posterior", "left"])]
+    pub views: Vec<View>,
 }
 
 pub struct UserInputs {
@@ -35,10 +39,8 @@ fn main() {
     init_logger();
 
     let args = Args::parse();
-    println!("{args:?}");
-
     let (nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
-    let slicer = Slicer::from_3d(nifti_header, data, 3, View::Anterior, (0.3, 0.7));
+    let slicer = Slicer::from_3d(nifti_header, data, 3, &args.views, (0.3, 0.7));
     for slice in slicer.slices {
         let inputs = UserInputs {
             src_img: slice.data,

--- a/src/slicer.rs
+++ b/src/slicer.rs
@@ -1,0 +1,151 @@
+use std::str::FromStr;
+
+use ndarray::{Array2, Array3, ShapeBuilder};
+use nifti::NiftiHeader;
+
+pub type ImageSlice = Array2<u8>;
+pub type Spacing = (f32, f32, f32);
+
+#[derive(Copy, Clone, Debug)]
+pub enum Axis {
+    Sagittal = 0,
+    Coronal,
+    Axial,
+}
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+pub enum View {
+    Left,
+    Right, // TODO Switch camera
+    Anterior,
+    Posterior, // TODO Switch camera
+    Superior,
+    Inferior, // TODO Switch camera
+}
+
+impl FromStr for View {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<View, Self::Err> {
+        match input {
+            "left" => Ok(View::Left),
+            "right" => Ok(View::Right),
+            "anterior" => Ok(View::Anterior),
+            "posterior" => Ok(View::Posterior),
+            "superior" => Ok(View::Superior),
+            "inferior" => Ok(View::Inferior),
+            _ => Err(()),
+        }
+    }
+}
+
+impl View {
+    pub fn axis(&self) -> Axis {
+        match self {
+            View::Left | View::Right => Axis::Sagittal,
+            View::Anterior | View::Posterior => Axis::Coronal,
+            View::Superior | View::Inferior => Axis::Axial,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            View::Left => "left",
+            View::Right => "right",
+            View::Anterior => "anterior",
+            View::Posterior => "posterior",
+            View::Superior => "superior",
+            View::Inferior => "inferior",
+        }
+    }
+}
+
+pub struct Slice {
+    pub data: ImageSlice,
+    pub view: View,
+    pub index: usize,
+    pub depth: f32,
+}
+
+pub struct Slicer {
+    pub header: NiftiHeader,
+    pub spacing: Spacing,
+    pub slices: Vec<Slice>,
+}
+
+impl Slicer {
+    pub fn from_3d(
+        header: NiftiHeader,
+        data: Array3<f32>,
+        nb_slices: usize,
+        views: &[View],
+        range: (f32, f32),
+    ) -> Self {
+        // Rescale whatever we've got to u8
+        let min_value = data.fold(f32::MAX, |acc, &v| f32::min(acc, v));
+        let max_value = data.fold(f32::MIN, |acc, &v| f32::max(acc, v));
+        let image_range = max_value - min_value;
+        let type_min = 0.0;
+        let type_max = 255.0;
+        let type_range = type_max - type_min;
+        let rescale = |x| ((x - min_value) * (type_range / image_range) + type_min) as u8;
+        let spacing = (header.pixdim[1], header.pixdim[2], header.pixdim[3]);
+
+        // I tried doing a views.flat_map(indices.map()) but I have a borrow checker problem that
+        // I'm unsable to fix.
+        let mut slices = Vec::with_capacity(views.len() * nb_slices);
+        for &view in views {
+            let axis = view.clone().axis();
+            for idx in build_indices(&data, nb_slices, axis, range) {
+                let slice: Array2<u8> = data
+                    .index_axis(ndarray::Axis(axis as usize), idx)
+                    .mapv(rescale);
+
+                // A NIfTI image is stored in 'f' order, but it doesn't know that much itself
+                // so ndarray thinks it's the standard 'c' order. Because of this, we convert
+                // it to 'f' order, which actually converts it to 'c' order. Voilà.
+                let mut data_c = Array2::zeros(slice.dim().f());
+                data_c.assign(&slice);
+
+                slices.push(Slice {
+                    data: data_c,
+                    view,
+                    index: idx,
+                    depth: 0.0, // TODO Spacing * index
+                });
+            }
+        }
+
+        Slicer {
+            header,
+            spacing,
+            slices,
+        }
+    }
+}
+
+fn build_indices(
+    data: &Array3<f32>,
+    mut nb_slices: usize,
+    axis: Axis,
+    range: (f32, f32),
+) -> Vec<usize> {
+    // TODO We can calculate the bbox to avoid the blank zones
+    let width = data.shape()[axis as usize] as f32;
+    let max_idx = width * range.1;
+    let min_idx = width * range.0;
+
+    if nb_slices == 1 {
+        // User requested a single image. Lets give him the middle slice.
+        vec![((min_idx + max_idx) / 2.0).round() as usize]
+    } else {
+        let mut step = (max_idx - min_idx) / (nb_slices - 1) as f32;
+        if step < 1.0 {
+            nb_slices = ((nb_slices + 1) as f32 * step) as usize;
+            step = 1.0;
+        }
+        (0..nb_slices)
+            .map(|i| (i as f32 * step + min_idx).round() as usize)
+            .collect()
+    }
+}


### PR DESCRIPTION
Use `Anatomy.zip` from this [drive](https://drive.google.com/drive/folders/1-FMRFEKCh28TOrh1Ui5qJJLvmq69hgn-). Those are free images available with MI-Brain.

    cargo run --release -- ./Subject__t1_brain_on_b0.nii.gz ./test.png

As you can see, it kinda works :|
- The output image is red. I think this is caused by `TextureFormat::R8Unorm` but I don't know which one to use for "grayscale". I could keep `TextureFormat::Rgba8Unorm` and create 3-tuple with all values but it seems wasteful.
- The damn image is upside down! I know this is normal because all textures are reversed, but I thought you had already fixed this because your dog image appears ok.
  -  I tried making it ok by playing with the order of the parameters in extent, with transpose, with the memory order, but I'm pretty sure my setup is ok now.

Can you please help me? :)