### PR TITLE
Streamline batching, improved imports and white mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ This is **not** an image viewer (like [MI-Brain](https://github.com/imeka/mi-bra
 
 - [x] Display toy image data and save the result to png
 - [x] Choose the surface dimension
-- [ ] Load actual NIfTI files, using [nifti-rs](https://github.com/Enet4/nifti-rs)
-- [ ] Save several image slices instead of one
-- [ ] Display toy streamlines/fibers, using [trk-io](https://github.com/imeka/trk-io)
-- [ ] Load actual TrackVis files
+- [x] Load actual NIfTI files, using [nifti-rs](https://github.com/Enet4/nifti-rs)
+- [x] Save several image slices instead of one
+- [x] Display toy streamlines/fibers, using [trk-io](https://github.com/imeka/trk-io)
+- [x] Load actual TrackVis files
 - [ ] Add various streamlines display options
 
 The following features might be added
 
 - [ ] Display characters in the image
-- [ ] White background option (instead of black)
+- [x] White background option (instead of black)
 - [ ] LUT to color the image

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This is **not** an image viewer (like [MI-Brain](https://github.com/imeka/mi-bra
 - [x] Load actual NIfTI files, using [nifti-rs](https://github.com/Enet4/nifti-rs)
 - [x] Save several image slices instead of one
 - [x] Display toy streamlines/fibers, using [trk-io](https://github.com/imeka/trk-io)
-- [x] Load actual TrackVis files
+- [ ] Load actual TrackVis files
 - [ ] Add various streamlines display options
 
 The following features might be added
 
 - [ ] Display characters in the image
-- [x] White background option (instead of black)
+- [ ] White background option (instead of black)
 - [ ] LUT to color the image

--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -1,15 +1,17 @@
 use glam::UVec2;
-use wgpu::{Adapter, Device, Queue};
+use wgpu::{Adapter, Device, Features, Queue};
 
 use super::ContextInputs;
 use crate::graphics::resources::COLOR_FORMAT;
 
-/// Stores handlers related to the user environment
+/// Stores handlers related to the user environment and various parameters.
 pub struct Client {
     pub device: Device,
     pub command_queue: Queue,
     pub img_size: UVec2,
     pub multisample_count: u32,
+    pub streamline_batch_size: usize,
+    pub white_mode: bool,
 }
 
 impl Client {
@@ -24,6 +26,8 @@ impl Client {
             command_queue,
             img_size: inputs.dst_img_size,
             multisample_count: max_multisample_count(&adapter),
+            streamline_batch_size: inputs.streamline_batch_size,
+            white_mode: inputs.white_mode,
         }
     }
 }
@@ -39,10 +43,9 @@ fn max_multisample_count(adapter: &Adapter) -> u32 {
 }
 
 async fn device(adapter: &Adapter) -> (Device, Queue) {
-    use wgpu::Features;
-
-    let required_features =
-        Features::POLYGON_MODE_LINE | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+    let required_features = Features::POLYGON_MODE_LINE
+        | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
+        | Features::ADDRESS_MODE_CLAMP_TO_BORDER;
 
     let desc = &wgpu::DeviceDescriptor {
         label: None,

--- a/src/graphics/pipeline.rs
+++ b/src/graphics/pipeline.rs
@@ -1,4 +1,7 @@
-use wgpu::{BindGroupLayout, ColorTargetState, Device, RenderPipeline};
+use wgpu::{
+    BindGroupLayout, ColorTargetState, CompareFunction, DepthStencilState, Device,
+    MultisampleState, RenderPipeline,
+};
 
 use super::{
     resources::{vertex::Vertex, Resources, COLOR_FORMAT, DEPTH_FORMAT},
@@ -17,11 +20,11 @@ pub struct Pipelines {
 
 impl Pipelines {
     pub fn new(res: &Resources, client: &Client) -> Self {
-        let streamline = res
-            .fibers
-            .as_ref()
-            .map(|_| create_pipeline(state::streamline(), res, client));
-
+        let streamline = if !res.fibers.is_empty() {
+            Some(create_pipeline(state::streamline(), res, client))
+        } else {
+            None
+        };
         Self {
             resampling: create_pipeline(state::resampling(), res, client),
             streamline,
@@ -95,13 +98,13 @@ fn color_target() -> ColorTargetState {
     }
 }
 
-fn depth_stencil(active: bool) -> wgpu::DepthStencilState {
+fn depth_stencil(active: bool) -> DepthStencilState {
     let depth_compare = if active {
-        wgpu::CompareFunction::Less
+        CompareFunction::LessEqual
     } else {
-        wgpu::CompareFunction::Always
+        CompareFunction::Always
     };
-    wgpu::DepthStencilState {
+    DepthStencilState {
         format: DEPTH_FORMAT,
         depth_write_enabled: active,
         depth_compare,
@@ -110,8 +113,8 @@ fn depth_stencil(active: bool) -> wgpu::DepthStencilState {
     }
 }
 
-fn multisample(count: u32) -> wgpu::MultisampleState {
-    wgpu::MultisampleState {
+fn multisample(count: u32) -> MultisampleState {
+    MultisampleState {
         count,
         mask: !0,
         alpha_to_coverage_enabled: false,

--- a/src/graphics/pipeline.rs
+++ b/src/graphics/pipeline.rs
@@ -20,11 +20,9 @@ pub struct Pipelines {
 
 impl Pipelines {
     pub fn new(res: &Resources, client: &Client) -> Self {
-        let streamline = if !res.fibers.is_empty() {
-            Some(create_pipeline(state::streamline(), res, client))
-        } else {
-            None
-        };
+        let streamline =
+            (!res.fibers.is_empty()).then(|| create_pipeline(state::streamline(), res, client));
+
         Self {
             resampling: create_pipeline(state::resampling(), res, client),
             streamline,

--- a/src/graphics/resources/bind/layout.rs
+++ b/src/graphics/resources/bind/layout.rs
@@ -1,4 +1,7 @@
-use wgpu::{BindGroupLayout, BindingType, Device, ShaderStages};
+use wgpu::{
+    BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry, BindingType, Device,
+    ShaderStages,
+};
 
 struct LayoutEntry {
     stage: ShaderStages,
@@ -36,8 +39,6 @@ pub fn transform(device: &Device) -> BindGroupLayout {
 }
 
 fn create_layout(name: &str, entries: &[LayoutEntry], device: &Device) -> BindGroupLayout {
-    use wgpu::{BindGroupLayoutDescriptor, BindGroupLayoutEntry};
-
     let entry = |(i, entry): (usize, &LayoutEntry)| BindGroupLayoutEntry {
         binding: i as u32,
         visibility: entry.stage,

--- a/src/graphics/resources/fibers.rs
+++ b/src/graphics/resources/fibers.rs
@@ -1,20 +1,22 @@
 use std::ops::Range;
 
 use nalgebra::Vector3;
-use trk_io::Reader;
+use trk_io::{Point, Reader};
 use wgpu::{Buffer, Device};
 
-use super::{buffer, vertex::FiberVertex};
+use super::{buffer, vertex::FiberVertex, Client};
 
-pub struct FiberResources {
+type Streamline = Vec<Point>;
+
+pub struct FiberBatch {
     pub vertices: Buffer,
     pub indices: Buffer,
     pub index_count: u32,
 }
 
-impl FiberResources {
-    pub fn new(fibers: Reader, device: &Device) -> Self {
-        let (vertices, indices) = fiber_geometry(fibers);
+impl FiberBatch {
+    fn new(streamlines: Vec<Streamline>, device: &Device) -> Self {
+        let (vertices, indices) = geometry(streamlines);
         let name = "Fiber";
 
         Self {
@@ -25,12 +27,23 @@ impl FiberResources {
     }
 }
 
-fn fiber_geometry(fibers: Reader) -> (Vec<FiberVertex>, Vec<u32>) {
-    let (mut vertices, ranges) = fiber_vertices(fibers);
+pub fn batches(fibers: Reader, client: &Client) -> Vec<FiberBatch> {
+    let mut iter = fibers.into_streamlines_iter().peekable();
+    let mut batches = vec![];
+
+    while iter.peek().is_some() {
+        let streamlines = iter.by_ref().take(client.streamline_batch_size).collect();
+        batches.push(FiberBatch::new(streamlines, &client.device));
+    }
+    batches
+}
+
+fn geometry(streamlines: Vec<Streamline>) -> (Vec<FiberVertex>, Vec<u32>) {
+    let (mut vertices, ranges) = vertices(streamlines);
     let mut indices: Vec<u32> = Vec::with_capacity((vertices.len() - ranges.len()) * 2);
 
     for range in ranges {
-        for i in range.start..range.end - 1 {
+        for i in range.start..range.end {
             vertices[i].direction = (vertices[i + 1].position - vertices[i].position).normalize();
             indices.extend([i as u32, i as u32 + 1]);
         }
@@ -40,12 +53,12 @@ fn fiber_geometry(fibers: Reader) -> (Vec<FiberVertex>, Vec<u32>) {
     (vertices, indices)
 }
 
-fn fiber_vertices(fibers: Reader) -> (Vec<FiberVertex>, Vec<Range<usize>>) {
+fn vertices(streamlines: Vec<Streamline>) -> (Vec<FiberVertex>, Vec<Range<usize>>) {
     let mut delimiter = 0;
     let mut ranges = vec![]; // Streamlines ranges
 
-    let vertices: Vec<FiberVertex> = fibers
-        .into_streamlines_iter()
+    let vertices: Vec<FiberVertex> = streamlines
+        .into_iter()
         .flat_map(|streamline| {
             let start = delimiter;
             ranges.push(start..start + streamline.len() - 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,17 @@ struct Args {
     /// Input NIfTI image
     pub input_image: PathBuf,
 
+    /// Use a white background instead of black
+    #[arg(short, long, default_value = "false")]
+    pub white: bool,
+
     /// Output folder to save all png
     #[arg(short, long)]
     pub fibers: Option<PathBuf>,
+
+    /// How many streamlines are batched per buffer
+    #[arg(short, long, default_value = "50000")]
+    pub batch_size: usize,
 
     /// Output folder to save all png
     pub output: PathBuf,
@@ -38,6 +46,8 @@ struct Args {
 pub struct ContextInputs {
     pub fibers_reader: Option<Reader>,
     pub dst_img_size: UVec2,
+    pub streamline_batch_size: usize,
+    pub white_mode: bool,
 }
 
 fn main() {
@@ -54,6 +64,8 @@ fn main() {
     let inputs = ContextInputs {
         fibers_reader,
         dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
+        streamline_batch_size: args.batch_size,
+        white_mode: args.white,
     };
     let mut graphics = graphics::Context::new(inputs);
 


### PR DESCRIPTION
Fixes #14 

- Replaced `FiberResources` with a vector of `FiberBatch`. Multiple buffers are now created instead of a single one to hold a bunch of streamlines. This code does not account for the maximum buffer size and the size of streamlines. This could cause allocation errors if the device can't support the size of a batch. I'm not sure this will occur often in practice, but I added the `batch_size` parameter just in case.
- Added support for a white background using the `white` parameter.
- Cleaned some imports to comply with the preferred import style.