### PR TITLE
Valid streamlines projection and uniform scaling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 bytemuck = { version = "1.16", features = ["derive"] } # Raw data manipulations
 clap = { version = "4.5.8", features = ["derive"] }
 env_logger = "0.11" # Logging client
-glam = { version = "0.27", features = ["bytemuck"] } # Fast math types
+glam = { version = "0.29", features = ["bytemuck"] } # Fast math types
 image = "0.25" # Image encoders/decoders 
 log = "0.4" # Logging API
 nalgebra = { version = "0.32", features = ["bytemuck"] } # Math types of trk-io

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is **not** an image viewer (like [MI-Brain](https://github.com/imeka/mi-bra
 - [x] Load actual NIfTI files, using [nifti-rs](https://github.com/Enet4/nifti-rs)
 - [x] Save several image slices instead of one
 - [x] Display toy streamlines/fibers, using [trk-io](https://github.com/imeka/trk-io)
-- [ ] Load actual TrackVis files
+- [X] Load actual TrackVis files
 - [ ] Add various streamlines display options
 
 The following features might be added

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,16 +1,18 @@
 use crate::{slicer::Slice, ContextInputs, Image};
-use {client::Client, pipeline::Pipelines, resources::Resources};
+use {client::Client, parameters::Parameters, pipeline::Pipelines, resources::Resources};
 
 #[macro_use]
 mod macros;
 
 mod client;
+mod parameters;
 mod pipeline;
 mod resources;
 mod workload;
 
 pub struct Context {
     client: Client,
+    parameters: Parameters,
     res: Resources,
     pipelines: Pipelines,
 }
@@ -18,12 +20,14 @@ pub struct Context {
 impl Context {
     pub fn new(inputs: ContextInputs) -> Self {
         let client = pollster::block_on(Client::new(&inputs));
+        let parameters = Parameters::new(&inputs);
         let res = Resources::new(inputs.fibers_reader, &client);
 
         Self {
             pipelines: Pipelines::new(&res, &client),
-            res,
             client,
+            parameters,
+            res,
         }
     }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,4 +1,4 @@
-use crate::{ContextInputs, Image, ImageSlice};
+use crate::{slicer::Slice, ContextInputs, Image};
 use {client::Client, pipeline::Pipelines, resources::Resources};
 
 #[macro_use]
@@ -27,7 +27,7 @@ impl Context {
         }
     }
 
-    pub fn process_slice(&mut self, image: &ImageSlice) -> Image {
-        self.execute_workloads(image)
+    pub fn process_slice(&mut self, slice: &Slice) -> Image {
+        self.execute_workloads(slice)
     }
 }

--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -45,9 +45,8 @@ fn max_multisample_count(adapter: &Adapter) -> u32 {
 }
 
 async fn device(adapter: &Adapter) -> (Device, Queue) {
-    let required_features = Features::POLYGON_MODE_LINE
-        | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
-        | Features::ADDRESS_MODE_CLAMP_TO_BORDER;
+    let required_features =
+        Features::POLYGON_MODE_LINE | Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
 
     let desc = &wgpu::DeviceDescriptor {
         label: None,

--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -1,4 +1,4 @@
-use glam::{UVec2, UVec3};
+use glam::UVec2;
 use wgpu::{Adapter, Device, Features, Queue};
 
 use super::ContextInputs;
@@ -9,10 +9,8 @@ pub struct Client {
     pub device: Device,
     pub command_queue: Queue,
     pub img_size: UVec2,
-    pub size_3d: UVec3,
     pub multisample_count: u32,
     pub streamline_batch_size: usize,
-    pub white_mode: bool,
 }
 
 impl Client {
@@ -26,10 +24,8 @@ impl Client {
             device,
             command_queue,
             img_size: inputs.dst_img_size,
-            size_3d: inputs.size_3d,
             multisample_count: max_multisample_count(&adapter),
             streamline_batch_size: inputs.streamline_batch_size,
-            white_mode: inputs.white_mode,
         }
     }
 }

--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -1,4 +1,4 @@
-use glam::UVec2;
+use glam::{UVec2, UVec3};
 use wgpu::{Adapter, Device, Features, Queue};
 
 use super::ContextInputs;
@@ -9,6 +9,7 @@ pub struct Client {
     pub device: Device,
     pub command_queue: Queue,
     pub img_size: UVec2,
+    pub size_3d: UVec3,
     pub multisample_count: u32,
     pub streamline_batch_size: usize,
     pub white_mode: bool,
@@ -25,6 +26,7 @@ impl Client {
             device,
             command_queue,
             img_size: inputs.dst_img_size,
+            size_3d: inputs.size_3d,
             multisample_count: max_multisample_count(&adapter),
             streamline_batch_size: inputs.streamline_batch_size,
             white_mode: inputs.white_mode,

--- a/src/graphics/parameters.rs
+++ b/src/graphics/parameters.rs
@@ -1,0 +1,44 @@
+use glam::{vec2, Mat4, Vec2, Vec3};
+
+use super::ContextInputs;
+
+pub struct Parameters {
+    pub fit_scale: f32,
+    pub tractogram_alignment: Mat4,
+    pub tractogram_projection: Mat4,
+    pub white_mode: bool,
+}
+
+impl Parameters {
+    pub fn new(inputs: &ContextInputs) -> Self {
+        let (dst_size, size_3d) = (inputs.dst_img_size.as_vec2(), inputs.size_3d.as_vec3());
+        let fit_scale = fit_scale(dst_size, size_3d);
+
+        Self {
+            fit_scale,
+            tractogram_projection: tractogram_projection(dst_size, fit_scale * size_3d),
+            tractogram_alignment: tractogram_alignment(fit_scale, size_3d),
+            white_mode: inputs.white_mode,
+        }
+    }
+}
+
+/// Calculates the maximum scaling factor that fits within boundaries,
+/// maintains the aspect ratio, and ensures uniformity across all three axes.
+fn fit_scale(dst_size: Vec2, size_3d: Vec3) -> f32 {
+    let max_size = vec2(size_3d.x, size_3d.z).max(vec2(size_3d.y, size_3d.y));
+    (dst_size / max_size).min_element()
+}
+
+// Centers the tractogram's bounding box at the origin (0, 0) and applies scaling.
+fn tractogram_alignment(fit_scale: f32, size_3d: Vec3) -> Mat4 {
+    Mat4::from_scale(Vec3::splat(fit_scale)) * Mat4::from_translation(-size_3d / 2.)
+}
+
+/// Creates an orthographic projection matrix. This is used to change the basis from
+/// voxel space to screen space and also defines the depth range.
+fn tractogram_projection(dst_size: Vec2, scaled_size_3d: Vec3) -> Mat4 {
+    let half = dst_size / 2.;
+    let depth = scaled_size_3d.max_element() / 2.;
+    Mat4::orthographic_rh(-half.x, half.x, -half.y, half.y, -depth, depth)
+}

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
-use glam::Mat4;
+use glam::{swizzles::Vec3Swizzles, vec2, vec3, Mat3, Mat4, Vec2};
 use trk_io::Reader;
 use wgpu::{BindGroupLayout, Buffer};
 
 use crate::graphics::Client;
 use fibers::FiberBatch;
+use vertex::ImageVertex;
 
 pub use texture::{Texture, COLOR_FORMAT, DEPTH_FORMAT};
 
@@ -63,4 +64,19 @@ impl Resources {
             transform: buffer::create_transform(Mat4::IDENTITY, device),
         }
     }
+}
+
+pub fn quad_vertices(src_size: Vec2, transform: Mat3) -> [ImageVertex; 6] {
+    let vertex = |x, y, u, v| ImageVertex {
+        canon: (transform * vec3(x * src_size.x, y * src_size.y, 1.)).xy(),
+        uv: vec2(u, v),
+    };
+    [
+        vertex(1., 1., 0., 1.),
+        vertex(1., 0., 0., 0.),
+        vertex(0., 0., 1., 0.),
+        vertex(1., 1., 0., 1.),
+        vertex(0., 0., 1., 0.),
+        vertex(0., 1., 1., 1.),
+    ]
 }

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use glam::{swizzles::Vec3Swizzles, vec2, vec3, Mat3, Mat4, Vec2};
+use glam::{vec2, Mat3, Mat4, Vec2};
 use trk_io::Reader;
 use wgpu::{BindGroupLayout, Buffer};
 
@@ -68,7 +68,7 @@ impl Resources {
 
 pub fn quad_vertices(src_size: Vec2, transform: Mat3) -> [ImageVertex; 6] {
     let vertex = |x, y, u, v| ImageVertex {
-        canon: (transform * vec3(x * src_size.x, y * src_size.y, 1.)).xy(),
+        canon: transform.transform_point2(vec2(x * src_size.x, y * src_size.y)),
         uv: vec2(u, v),
     };
     [

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use glam::{vec2, Mat3, Mat4, Vec2};
+use glam::{vec2, Mat3, Mat4};
 use trk_io::Reader;
 use wgpu::{BindGroupLayout, Buffer};
 
@@ -66,17 +66,17 @@ impl Resources {
     }
 }
 
-pub fn quad_vertices(src_size: Vec2, transform: Mat3) -> [ImageVertex; 6] {
+pub fn quad_vertices(transform: Mat3) -> [ImageVertex; 6] {
     let vertex = |x, y, u, v| ImageVertex {
-        canon: transform.transform_point2(vec2(x * src_size.x, y * src_size.y)),
+        canon: transform.transform_point2(vec2(x, y)),
         uv: vec2(u, v),
     };
     [
         vertex(1., 1., 0., 1.),
-        vertex(1., 0., 0., 0.),
-        vertex(0., 0., 1., 0.),
+        vertex(1., -1., 0., 0.),
+        vertex(-1., -1., 1., 0.),
         vertex(1., 1., 0., 1.),
-        vertex(0., 0., 1., 0.),
-        vertex(0., 1., 1., 1.),
+        vertex(-1., -1., 1., 0.),
+        vertex(-1., 1., 1., 1.),
     ]
 }

--- a/src/graphics/resources/bind/group.rs
+++ b/src/graphics/resources/bind/group.rs
@@ -1,6 +1,4 @@
-use wgpu::{
-    AddressMode, BindGroup, BindGroupEntry, BindingResource, FilterMode, SamplerBorderColor,
-};
+use wgpu::{AddressMode, BindGroup, BindGroupEntry, BindingResource, FilterMode};
 
 use crate::{
     graphics::{resources::Texture, Client, Context},
@@ -24,17 +22,11 @@ pub fn transform(ctx: &Context) -> BindGroup {
 }
 
 fn create_sampler(client: &Client) -> wgpu::Sampler {
-    let border_color = if client.white_mode {
-        SamplerBorderColor::OpaqueWhite
-    } else {
-        SamplerBorderColor::OpaqueBlack
-    };
     client.device.create_sampler(&wgpu::SamplerDescriptor {
-        address_mode_u: AddressMode::ClampToBorder,
-        address_mode_v: AddressMode::ClampToBorder,
+        address_mode_u: AddressMode::ClampToEdge,
+        address_mode_v: AddressMode::ClampToEdge,
         mag_filter: FilterMode::Linear,
         min_filter: FilterMode::Linear,
-        border_color: Some(border_color),
         ..Default::default()
     })
 }

--- a/src/graphics/resources/bind/group.rs
+++ b/src/graphics/resources/bind/group.rs
@@ -2,7 +2,10 @@ use wgpu::{
     AddressMode, BindGroup, BindGroupEntry, BindingResource, FilterMode, SamplerBorderColor,
 };
 
-use crate::graphics::{resources::Texture, Client, Context, ImageSlice};
+use crate::{
+    graphics::{resources::Texture, Client, Context},
+    ImageSlice,
+};
 
 pub fn source(image: &ImageSlice, ctx: &Context) -> BindGroup {
     let sampler = create_sampler(&ctx.client);

--- a/src/graphics/resources/buffer.rs
+++ b/src/graphics/resources/buffer.rs
@@ -1,5 +1,5 @@
 use bytemuck::Pod;
-use glam::{Mat3, Mat4, Vec2};
+use glam::{Mat3, Mat4};
 use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
     Buffer, BufferUsages, Device,
@@ -10,7 +10,7 @@ use crate::graphics::resources::{quad_vertices, Texture};
 pub fn init_image_vertex_buffer(device: &Device) -> Buffer {
     device.create_buffer_init(&BufferInitDescriptor {
         label: label!("ImageVertexBuffer"),
-        contents: bytemuck::cast_slice(&quad_vertices(Vec2::ZERO, Mat3::ZERO)),
+        contents: bytemuck::cast_slice(&quad_vertices(Mat3::ZERO)),
         usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
     })
 }

--- a/src/graphics/resources/buffer.rs
+++ b/src/graphics/resources/buffer.rs
@@ -1,19 +1,16 @@
 use bytemuck::Pod;
-use glam::{vec2, Mat4, UVec2, Vec2};
+use glam::{Mat3, Mat4, Vec2};
 use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
     Buffer, BufferUsages, Device,
 };
 
-use crate::graphics::{
-    resources::{vertex::ImageVertex, Texture},
-    Context,
-};
+use crate::graphics::resources::{quad_vertices, Texture};
 
 pub fn init_image_vertex_buffer(device: &Device) -> Buffer {
     device.create_buffer_init(&BufferInitDescriptor {
         label: label!("ImageVertexBuffer"),
-        contents: bytemuck::cast_slice(&quad_vertices(Vec2::ZERO)),
+        contents: bytemuck::cast_slice(&quad_vertices(Vec2::ZERO, Mat3::ZERO)),
         usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
     })
 }
@@ -32,61 +29,6 @@ pub fn init_indices(name: &str, indices: &[u32], device: &Device) -> Buffer {
         contents: bytemuck::cast_slice(indices),
         usage: BufferUsages::INDEX,
     })
-}
-
-impl Context {
-    pub fn set_image_vertices(&self, size: UVec2) {
-        let vertices = quad_vertices(uv_offset(size, self.client.img_size));
-        let bytes = bytemuck::cast_slice(&vertices);
-
-        self.client
-            .command_queue
-            .write_buffer(&self.res.image_vertices, 0, bytes);
-    }
-
-    pub fn set_transform(&self, transform: Mat4) {
-        let transform = &[transform];
-        let bytes = bytemuck::cast_slice(transform);
-
-        self.client
-            .command_queue
-            .write_buffer(&self.res.transform, 0, bytes);
-    }
-}
-
-/// Calculates the UV offset needed to maintain the source image's aspect ratio
-fn uv_offset(src_size: UVec2, dst_size: UVec2) -> Vec2 {
-    let (src_size, dst_size) = (src_size.as_vec2(), dst_size.as_vec2());
-
-    let ratio = dst_size / src_size;
-
-    if ratio.x > ratio.y {
-        let img_w = src_size.x * ratio.y;
-        vec2((dst_size.x - img_w) / (2. * img_w), 0.)
-    } else {
-        let img_h = src_size.y * ratio.x;
-        vec2(0., (dst_size.y - img_h) / (2. * img_h))
-    }
-}
-
-fn quad_vertices(uv_offset: Vec2) -> [ImageVertex; 6] {
-    let (du, dv) = (uv_offset.x, uv_offset.y);
-
-    let vertex = |x, y, u, v| ImageVertex {
-        canon: vec2(x, y),
-        uv: vec2(u, v),
-    };
-    // (n)egative and (p)ositive
-    let (nu, pu) = (0. - du, 1. + du);
-    let (nv, pv) = (0. - dv, 1. + dv);
-    [
-        vertex(1., 1., nu, pv),
-        vertex(1., -1., nu, nv),
-        vertex(-1., -1., pu, nv),
-        vertex(1., 1., nu, pv),
-        vertex(-1., -1., pu, nv),
-        vertex(-1., 1., pu, pv),
-    ]
 }
 
 pub fn create_transfer_buffer(texture: &Texture, device: &Device) -> Buffer {

--- a/src/graphics/resources/texture.rs
+++ b/src/graphics/resources/texture.rs
@@ -1,7 +1,7 @@
 use glam::UVec2;
 use wgpu::{Extent3d, ImageCopyTexture, ImageDataLayout, Queue, TextureFormat, TextureUsages};
 
-use crate::graphics::{Client, ImageSlice};
+use crate::{graphics::Client, ImageSlice};
 
 pub const GRAY_FORMAT: TextureFormat = TextureFormat::R8Unorm;
 pub const COLOR_FORMAT: TextureFormat = TextureFormat::Rgba8Unorm;

--- a/src/graphics/resources/vertex.rs
+++ b/src/graphics/resources/vertex.rs
@@ -22,7 +22,7 @@ where
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable, Debug)]
+#[derive(Copy, Clone, Pod, Zeroable)]
 pub struct ImageVertex {
     pub canon: Vec2,
     pub uv: Vec2,

--- a/src/graphics/resources/vertex.rs
+++ b/src/graphics/resources/vertex.rs
@@ -22,7 +22,7 @@ where
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Pod, Zeroable)]
+#[derive(Copy, Clone, Pod, Zeroable, Debug)]
 pub struct ImageVertex {
     pub canon: Vec2,
     pub uv: Vec2,

--- a/src/graphics/workload.rs
+++ b/src/graphics/workload.rs
@@ -43,12 +43,10 @@ impl Context {
     }
 
     fn slice_transform(&self, slice: &Slice) -> Mat3 {
-        let dst_size = self.client.img_size.as_vec2();
+        let screen_space_scale =
+            self.parameters.fit_scale * slice.size().as_vec2() / self.client.img_size.as_vec2();
 
-        let screen_space_transform =
-            Mat3::from_scale(self.parameters.fit_scale * slice.size().as_vec2() / dst_size);
-
-        slice.view.orientation() * screen_space_transform
+        slice.view.orientation() * Mat3::from_scale(screen_space_scale)
     }
 
     fn write<T: Pod>(&self, buffer: &Buffer, data: T) {

--- a/src/graphics/workload.rs
+++ b/src/graphics/workload.rs
@@ -1,5 +1,5 @@
 use bytemuck::Pod;
-use glam::{vec2, Mat3, Mat4, Vec2, Vec3};
+use glam::Mat3;
 use wgpu::{Buffer, CommandEncoder};
 
 use crate::graphics::{resources::quad_vertices, Context, Image, Slice};
@@ -32,28 +32,23 @@ impl Context {
     }
 
     pub fn update_slice_data(&self, slice: &Slice) {
-        let client = &self.client;
+        let vertices = quad_vertices(self.slice_transform(slice));
 
-        let (src_size, dst_size) = (slice.size().as_vec2(), client.img_size.as_vec2());
-        let size_3d = client.size_3d.as_vec3();
-
-        let scale = scale(dst_size, size_3d);
-
-        let vertices = {
-            let quad_transform = slice.view.orientation()
-                * screen_space_transform(dst_size)
-                * Mat3::from_translation((dst_size - scale * src_size) / 2.)
-                * Mat3::from_scale(vec2(scale, scale));
-
-            quad_vertices(src_size, quad_transform)
-        };
-        let transform = fiber_projection(dst_size, size_3d, scale)
-            * Mat4::from_scale(Vec3::splat(scale))
-            * slice.view.rotation()
-            * Mat4::from_translation(-size_3d / 2.);
+        let transform = self.parameters.tractogram_projection
+            * slice.view.rotation() // Rotates the tractogram according to the view
+            * self.parameters.tractogram_alignment;
 
         self.write(&self.res.image_vertices, vertices);
         self.write(&self.res.transform, transform);
+    }
+
+    fn slice_transform(&self, slice: &Slice) -> Mat3 {
+        let dst_size = self.client.img_size.as_vec2();
+
+        let screen_space_transform =
+            Mat3::from_scale(self.parameters.fit_scale * slice.size().as_vec2() / dst_size);
+
+        slice.view.orientation() * screen_space_transform
     }
 
     fn write<T: Pod>(&self, buffer: &Buffer, data: T) {
@@ -62,23 +57,4 @@ impl Context {
 
         self.client.command_queue.write_buffer(buffer, 0, bytes);
     }
-}
-
-/// Calculates the scaling factor with respect to
-/// the aspect ratio and uniformity across the three axes.
-fn scale(dst_size: Vec2, size_3d: Vec3) -> f32 {
-    let max_size = vec2(size_3d.x, size_3d.z).max(vec2(size_3d.y, size_3d.y));
-    (dst_size / max_size).min_element()
-}
-
-/// Find the change-of-basis matrix for the specified destination size.
-fn screen_space_transform(dst_size: Vec2) -> Mat3 {
-    Mat3::from_translation(vec2(-1., -1.)) * Mat3::from_scale(2. / dst_size)
-}
-
-/// Creates an orthographic projection matrix aligned with the slice images.
-fn fiber_projection(dst_size: Vec2, size_3d: Vec3, scale: f32) -> Mat4 {
-    let rect = dst_size / 2.;
-    let depth = scale * size_3d.max_element() / 2.;
-    Mat4::orthographic_rh(-rect.x, rect.x, -rect.y, rect.y, -depth, depth)
 }

--- a/src/graphics/workload.rs
+++ b/src/graphics/workload.rs
@@ -1,5 +1,5 @@
 use bytemuck::Pod;
-use glam::{vec2, vec3, Mat3, Mat4, Vec2, Vec3};
+use glam::{vec2, Mat3, Mat4, Vec2, Vec3};
 use wgpu::{Buffer, CommandEncoder};
 
 use crate::graphics::{resources::quad_vertices, Context, Image, Slice};
@@ -67,7 +67,7 @@ impl Context {
 /// Calculates the scaling factor with respect to
 /// the aspect ratio and uniformity across the three axes.
 fn scale(dst_size: Vec2, size_3d: Vec3) -> f32 {
-    let max_size = vec2(size_3d.x, size_3d.y).max(vec2(size_3d.z, size_3d.z));
+    let max_size = vec2(size_3d.x, size_3d.z).max(vec2(size_3d.y, size_3d.y));
     (dst_size / max_size).min_element()
 }
 

--- a/src/graphics/workload.rs
+++ b/src/graphics/workload.rs
@@ -1,23 +1,18 @@
-use glam::{uvec2, Mat4};
-use wgpu::CommandEncoder;
+use bytemuck::Pod;
+use glam::{vec2, vec3, Mat3, Mat4, Vec2, Vec3};
+use wgpu::{Buffer, CommandEncoder};
 
-use super::{Context, Image, ImageSlice};
+use crate::graphics::{resources::quad_vertices, Context, Image, Slice};
 
 mod render;
 mod transfer;
 
 impl Context {
-    pub fn execute_workloads(&self, image: &ImageSlice) -> Image {
+    pub fn execute_workloads(&self, slice: &Slice) -> Image {
         let mut command_encoder = self.command_encoder();
-        {
-            let (width, height) = image.dim();
-            self.set_image_vertices(uvec2(width as u32, height as u32));
 
-            let (width, height) = (width as f32, height as f32);
-            let projection = Mat4::orthographic_lh(0., width, 0., height, 0.01, 1000.);
-            self.set_transform(projection);
-        }
-        self.render_slice(image, &mut command_encoder);
+        self.update_slice_data(slice);
+        self.render_slice(&slice.data, &mut command_encoder);
         self.copy_target_to_buffer(&mut command_encoder);
 
         self.client.command_queue.submit([command_encoder.finish()]);
@@ -35,4 +30,55 @@ impl Context {
                 label: label!("CommandEncoder"),
             })
     }
+
+    pub fn update_slice_data(&self, slice: &Slice) {
+        let client = &self.client;
+
+        let (src_size, dst_size) = (slice.size().as_vec2(), client.img_size.as_vec2());
+        let size_3d = client.size_3d.as_vec3();
+
+        let scale = scale(dst_size, size_3d);
+
+        let vertices = {
+            let quad_transform = slice.view.orientation()
+                * screen_space_transform(dst_size)
+                * Mat3::from_translation((dst_size - scale * src_size) / 2.)
+                * Mat3::from_scale(vec2(scale, scale));
+
+            quad_vertices(src_size, quad_transform)
+        };
+        let transform = fiber_projection(dst_size, size_3d, scale)
+            * Mat4::from_scale(Vec3::splat(scale))
+            * slice.view.rotation()
+            * Mat4::from_translation(-size_3d / 2.);
+
+        self.write(&self.res.image_vertices, vertices);
+        self.write(&self.res.transform, transform);
+    }
+
+    fn write<T: Pod>(&self, buffer: &Buffer, data: T) {
+        let data = &[data];
+        let bytes = bytemuck::cast_slice(data);
+
+        self.client.command_queue.write_buffer(buffer, 0, bytes);
+    }
+}
+
+/// Calculates the scaling factor with respect to
+/// the aspect ratio and uniformity across the three axes.
+fn scale(dst_size: Vec2, size_3d: Vec3) -> f32 {
+    let max_size = vec2(size_3d.x, size_3d.y).max(vec2(size_3d.z, size_3d.z));
+    (dst_size / max_size).min_element()
+}
+
+/// Find the change-of-basis matrix for the specified destination size.
+fn screen_space_transform(dst_size: Vec2) -> Mat3 {
+    Mat3::from_translation(vec2(-1., -1.)) * Mat3::from_scale(2. / dst_size)
+}
+
+/// Creates an orthographic projection matrix aligned with the slice images.
+fn fiber_projection(dst_size: Vec2, size_3d: Vec3, scale: f32) -> Mat4 {
+    let rect = dst_size / 2.;
+    let depth = scale * size_3d.max_element() / 2.;
+    Mat4::orthographic_rh(-rect.x, rect.x, -rect.y, rect.y, -depth, depth)
 }

--- a/src/graphics/workload/render.rs
+++ b/src/graphics/workload/render.rs
@@ -1,4 +1,4 @@
-use wgpu::{CommandEncoder, Operations, RenderPassDepthStencilAttachment};
+use wgpu::{Color, CommandEncoder, Operations, RenderPassDepthStencilAttachment};
 
 use crate::{
     graphics::{
@@ -13,7 +13,7 @@ impl Context {
         let source_bind_group = bind::group::source(image, self);
         let transform_bind_group;
         {
-            let mut pass = render_pass(&self.res, command_encoder);
+            let mut pass = render_pass(&self.res, self.client.white_mode, command_encoder);
 
             // Resampling
             pass.set_bind_group(0, &source_bind_group, &[]);
@@ -48,12 +48,18 @@ impl Context {
 
 fn render_pass<'a>(
     res: &'a Resources,
+    white_mode: bool,
     command_encoder: &'a mut CommandEncoder,
 ) -> wgpu::RenderPass<'a> {
+    let clear_color = if white_mode {
+        Color::WHITE
+    } else {
+        Color::BLACK
+    };
     let color_attachment = wgpu::RenderPassColorAttachment {
         view: &res.multisampled_texture.view,
         resolve_target: Some(&res.target_texture.view),
-        ops: clear(wgpu::Color::WHITE),
+        ops: clear(clear_color),
     };
     command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: label!("RenderPass"),

--- a/src/graphics/workload/render.rs
+++ b/src/graphics/workload/render.rs
@@ -53,7 +53,7 @@ fn render_pass<'a>(
     let color_attachment = wgpu::RenderPassColorAttachment {
         view: &res.multisampled_texture.view,
         resolve_target: Some(&res.target_texture.view),
-        ops: clear(wgpu::Color::BLACK),
+        ops: clear(wgpu::Color::WHITE),
     };
     command_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: label!("RenderPass"),

--- a/src/graphics/workload/render.rs
+++ b/src/graphics/workload/render.rs
@@ -13,7 +13,7 @@ impl Context {
         let source_bind_group = bind::group::source(image, self);
         let transform_bind_group;
         {
-            let mut pass = render_pass(&self.res, self.client.white_mode, command_encoder);
+            let mut pass = render_pass(&self.res, self.parameters.white_mode, command_encoder);
 
             // Resampling
             pass.set_bind_group(0, &source_bind_group, &[]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,8 +64,6 @@ fn main() {
     let size_3d = get_dim(&nifti_header);
     let slicer = Slicer::from_3d(nifti_header, data, 3, &args.views, (0.3, 0.7));
 
-    println!("{:?}", size_3d);
-
     let inputs = ContextInputs {
         fibers_reader,
         size_3d,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, time::Instant};
 
 use clap::Parser;
-use glam::{uvec2, UVec2, UVec3};
+use glam::{uvec2, uvec3, UVec2, UVec3};
 use nifti::NiftiHeader;
 use trk_io::Reader;
 
@@ -90,8 +90,10 @@ fn get_dim(nifti_header: &NiftiHeader) -> UVec3 {
         .dim()
         .expect("The NIfTI must have consistent dimensions");
 
-    let dim: Vec<u32> = dim.iter().map(|&d| d as u32).collect();
-    UVec3::from_array(dim.try_into().expect("A 3D image is expected."))
+    if dim.len() != 3 {
+        panic!("A 3D image is expected.")
+    }
+    uvec3(dim[0] as u32, dim[1] as u32, dim[2] as u32)
 }
 
 fn init_logger() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::{path::PathBuf, time::Instant};
 
 use clap::Parser;
-use glam::{uvec2, UVec2};
+use glam::{uvec2, UVec2, UVec3};
+use nifti::NiftiHeader;
 use trk_io::Reader;
 
 use file::{fibers_reader, read_3d_image};
@@ -45,6 +46,7 @@ struct Args {
 
 pub struct ContextInputs {
     pub fibers_reader: Option<Reader>,
+    pub size_3d: UVec3,
     pub dst_img_size: UVec2,
     pub streamline_batch_size: usize,
     pub white_mode: bool,
@@ -59,10 +61,14 @@ fn main() {
     let (nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
     let fibers_reader = args.fibers.map(|path| fibers_reader(path, &nifti_header));
 
+    let size_3d = get_dim(&nifti_header);
     let slicer = Slicer::from_3d(nifti_header, data, 3, &args.views, (0.3, 0.7));
+
+    println!("{:?}", size_3d);
 
     let inputs = ContextInputs {
         fibers_reader,
+        size_3d,
         dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
         streamline_batch_size: args.batch_size,
         white_mode: args.white,
@@ -70,7 +76,7 @@ fn main() {
     let mut graphics = graphics::Context::new(inputs);
 
     for slice in slicer.slices {
-        let image = graphics.process_slice(&slice.data);
+        let image = graphics.process_slice(&slice);
 
         // TODO Support a prefix, like "prefix{}_{}.png"
         let mut write_to = args.output.clone();
@@ -79,6 +85,15 @@ fn main() {
     }
 
     log::info!("Program duration: {:?}", start.elapsed());
+}
+
+fn get_dim(nifti_header: &NiftiHeader) -> UVec3 {
+    let dim: &[u16] = nifti_header
+        .dim()
+        .expect("The NIfTI must have consistent dimensions");
+
+    let dim: Vec<u32> = dim.iter().map(|&d| d as u32).collect();
+    UVec3::from_array(dim.try_into().expect("A 3D image is expected."))
 }
 
 fn init_logger() {


### PR DESCRIPTION
- Slices are scaled uniformly based on how the largest dimension fits into the destination size.

- Respects view orientation; flips image horizontally when necessary.

  - Before ![before_sheet](https://github.com/user-attachments/assets/76d54d52-77a6-4df0-bde3-c35d3c3652f4)
  - After ![after_sheet](https://github.com/user-attachments/assets/1feff039-d139-488f-990b-5cd6177d5d5b)

- Simplified scaling code using linear algebra; moved code out of `buffer.rs` into `resources.rs` and `workload.rs`.

- The fibers are now aligned with the slice correctly, and the rotation is applied. These images match the visualization in MI-Brain.
  - ```
    cargo run --release -- --views left right anterior posterior superior inferior -f testdata/Bundles/CC4_AnteriorMidBody.trk testdata/Anatomy/Subject__t1_brain_on_b0.nii.gz fibers/
    ```
    ![fiber_sheet](https://github.com/user-attachments/assets/0d88d617-c77b-4789-9474-da9326ef11df)

- Background now uses a clear color instead of clamping; no more color limitation and blurry border effect.

- Upgraded `glam` to `0.29`. Might remove it in the future and use `nalgebra` exclusively instead.