### PR TITLE
Endpoint and uniform coloring mode selection

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -10,6 +10,8 @@ mod pipeline;
 mod resources;
 mod workload;
 
+pub use resources::Coloring;
+
 pub struct Context {
     client: Client,
     parameters: Parameters,

--- a/src/graphics/client.rs
+++ b/src/graphics/client.rs
@@ -2,7 +2,7 @@ use glam::UVec2;
 use wgpu::{Adapter, Device, Features, Queue};
 
 use super::ContextInputs;
-use crate::graphics::resources::COLOR_FORMAT;
+use crate::graphics::resources::{Coloring, COLOR_FORMAT};
 
 /// Stores handlers related to the user environment and various parameters.
 pub struct Client {
@@ -11,6 +11,8 @@ pub struct Client {
     pub img_size: UVec2,
     pub multisample_count: u32,
     pub streamline_batch_size: usize,
+    pub white_mode: bool,
+    pub coloring: Coloring,
 }
 
 impl Client {
@@ -26,6 +28,8 @@ impl Client {
             img_size: inputs.dst_img_size,
             multisample_count: max_multisample_count(&adapter),
             streamline_batch_size: inputs.streamline_batch_size,
+            white_mode: inputs.white_mode,
+            coloring: inputs.coloring,
         }
     }
 }

--- a/src/graphics/parameters.rs
+++ b/src/graphics/parameters.rs
@@ -6,7 +6,6 @@ pub struct Parameters {
     pub fit_scale: f32,
     pub tractogram_alignment: Mat4,
     pub tractogram_projection: Mat4,
-    pub white_mode: bool,
 }
 
 impl Parameters {
@@ -18,7 +17,6 @@ impl Parameters {
             fit_scale,
             tractogram_projection: tractogram_projection(dst_size, fit_scale * size_3d),
             tractogram_alignment: tractogram_alignment(fit_scale, size_3d),
-            white_mode: inputs.white_mode,
         }
     }
 }

--- a/src/graphics/pipeline/shaders/streamline.wgsl
+++ b/src/graphics/pipeline/shaders/streamline.wgsl
@@ -14,7 +14,7 @@ struct FragmentInput {
 fn vertex(in: VertexInput) -> FragmentInput {
     return FragmentInput(
         transform * vec4<f32>(in.position, 1.),
-        abs(in.direction)
+        in.direction
     );
 }
 

--- a/src/graphics/pipeline/shaders/streamline.wgsl
+++ b/src/graphics/pipeline/shaders/streamline.wgsl
@@ -2,7 +2,7 @@
 
 struct VertexInput {
     @location(0) position: vec3<f32>,
-    @location(1) direction: vec3<f32>,
+    @location(1) color: vec3<f32>,
 };
 
 struct FragmentInput {
@@ -14,7 +14,7 @@ struct FragmentInput {
 fn vertex(in: VertexInput) -> FragmentInput {
     return FragmentInput(
         transform * vec4<f32>(in.position, 1.),
-        in.direction
+        in.color
     );
 }
 

--- a/src/graphics/resources.rs
+++ b/src/graphics/resources.rs
@@ -8,13 +8,17 @@ use crate::graphics::Client;
 use fibers::FiberBatch;
 use vertex::ImageVertex;
 
-pub use texture::{Texture, COLOR_FORMAT, DEPTH_FORMAT};
+pub use {
+    coloring::Coloring,
+    texture::{Texture, COLOR_FORMAT, DEPTH_FORMAT},
+};
 
 pub mod bind {
     pub mod group;
     pub(super) mod layout;
 }
 mod buffer;
+mod coloring;
 mod fibers;
 mod texture;
 pub mod vertex;

--- a/src/graphics/resources/coloring.rs
+++ b/src/graphics/resources/coloring.rs
@@ -1,0 +1,53 @@
+use std::ops::Range;
+
+use nalgebra::Vector3;
+
+use super::vertex::FiberVertex;
+
+#[derive(Clone, Copy)]
+pub enum Coloring {
+    Local,
+    Endpoint,
+    Uniform(Vector3<u32>),
+}
+
+impl Coloring {
+    pub fn assign_vertex_colors(&self, vertices: &mut [FiberVertex], ranges: &[Range<usize>]) {
+        match self {
+            Coloring::Local => Self::assign_local_color(vertices, ranges),
+            Coloring::Endpoint => Self::assign_endpoint(vertices, ranges),
+            Coloring::Uniform(color) => Self::assign_uniform(vertices, *color),
+        }
+    }
+
+    fn assign_local_color(vertices: &mut [FiberVertex], ranges: &[Range<usize>]) {
+        for range in ranges {
+            for i in range.start..range.end {
+                vertices[i].color = (vertices[i + 1].position - vertices[i].position)
+                    .normalize()
+                    .abs();
+            }
+            // Last point of the streamline uses the previous color.
+            vertices[range.end].color = vertices[range.end - 1].color;
+        }
+    }
+
+    fn assign_endpoint(vertices: &mut [FiberVertex], ranges: &[Range<usize>]) {
+        for range in ranges {
+            let (first, last) = (&vertices[range.start], &vertices[range.end]);
+            let color = (first.position - last.position).normalize().abs();
+
+            for i in range.start..=range.end {
+                vertices[i].color = color
+            }
+        }
+    }
+
+    fn assign_uniform(vertices: &mut [FiberVertex], color: Vector3<u32>) {
+        let color = color.map(|c| c as f32 / 255.);
+
+        for vertex in vertices {
+            vertex.color = color;
+        }
+    }
+}

--- a/src/graphics/resources/coloring.rs
+++ b/src/graphics/resources/coloring.rs
@@ -37,8 +37,8 @@ impl Coloring {
             let (first, last) = (&vertices[range.start], &vertices[range.end]);
             let color = (first.position - last.position).normalize().abs();
 
-            for i in range.start..=range.end {
-                vertices[i].color = color
+            for vertex in &mut vertices[range.start..=range.end] {
+                vertex.color = color
             }
         }
     }

--- a/src/graphics/resources/coloring.rs
+++ b/src/graphics/resources/coloring.rs
@@ -14,13 +14,13 @@ pub enum Coloring {
 impl Coloring {
     pub fn assign_vertex_colors(&self, vertices: &mut [FiberVertex], ranges: &[Range<usize>]) {
         match self {
-            Coloring::Local => Self::assign_local_color(vertices, ranges),
+            Coloring::Local => Self::assign_local(vertices, ranges),
             Coloring::Endpoint => Self::assign_endpoint(vertices, ranges),
             Coloring::Uniform(color) => Self::assign_uniform(vertices, *color),
         }
     }
 
-    fn assign_local_color(vertices: &mut [FiberVertex], ranges: &[Range<usize>]) {
+    fn assign_local(vertices: &mut [FiberVertex], ranges: &[Range<usize>]) {
         for range in ranges {
             for i in range.start..range.end {
                 vertices[i].color = (vertices[i + 1].position - vertices[i].position)

--- a/src/graphics/resources/vertex.rs
+++ b/src/graphics/resources/vertex.rs
@@ -39,7 +39,7 @@ impl Vertex for ImageVertex {
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct FiberVertex {
     pub position: Point3<f32>,
-    pub direction: Vector3<f32>,
+    pub color: Vector3<f32>,
 }
 
 impl Vertex for FiberVertex {

--- a/src/graphics/workload/render.rs
+++ b/src/graphics/workload/render.rs
@@ -13,7 +13,7 @@ impl Context {
         let source_bind_group = bind::group::source(image, self);
         let transform_bind_group;
         {
-            let mut pass = render_pass(&self.res, self.parameters.white_mode, command_encoder);
+            let mut pass = render_pass(&self.res, self.client.white_mode, command_encoder);
 
             // Resampling
             pass.set_bind_group(0, &source_bind_group, &[]);

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -18,7 +18,7 @@ pub struct Args {
     #[arg(short, long, default_value = "false")]
     pub white: bool,
 
-    /// Output folder to save all png
+    /// Input TrackVis file
     #[arg(short, long)]
     pub fibers: Option<PathBuf>,
 
@@ -27,13 +27,14 @@ pub struct Args {
     pub batch_size: usize,
 
     /// Color mode for the fibers
-    #[arg(long, default_value = "local", requires("fibers"))]
+    #[arg(short, long, default_value = "local", requires("fibers"))]
     pub coloring: ColoringInput,
 
     /// RGB Color used by the uniform coloring mode
     #[arg(
         num_args(3),
         long,
+        requires("coloring"),
         required_if_eq("coloring", "uniform"),
         value_names = &["R", "G", "B"]
     )]

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -1,0 +1,109 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use glam::{uvec2, uvec3, UVec2, UVec3};
+use nalgebra::Vector3;
+use nifti::NiftiHeader;
+use trk_io::Reader;
+
+use super::{file::fibers_reader, graphics::Coloring, slicer::View};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Input NIfTI image
+    pub input_image: PathBuf,
+
+    /// Use a white background instead of black
+    #[arg(short, long, default_value = "false")]
+    pub white: bool,
+
+    /// Output folder to save all png
+    #[arg(short, long)]
+    pub fibers: Option<PathBuf>,
+
+    /// How many streamlines are batched per buffer
+    #[arg(short, long, default_value = "50000", requires("fibers"))]
+    pub batch_size: usize,
+
+    /// Color mode for the fibers
+    #[arg(long, default_value = "local", requires("fibers"))]
+    pub coloring: ColoringInput,
+
+    /// RGB Color used by the uniform coloring mode
+    #[arg(
+        num_args(3),
+        long,
+        required_if_eq("coloring", "uniform"),
+        value_names = &["R", "G", "B"]
+    )]
+    pub rgb: Vec<u32>,
+
+    /// Output folder to save all png
+    pub output: PathBuf,
+
+    /// Width and height of the output 2D image
+    #[arg(
+        num_args(2), 
+        long, 
+        default_values = ["800", "600"], 
+        value_names = &["WIDTH", "HEIGHT"] 
+    )]
+    pub output_size: Vec<u32>,
+
+    /// Which view(s) to use tp capture the image(s)
+    #[arg(num_args(1..7), long, default_values = ["superior", "posterior", "left"])]
+    pub views: Vec<View>,
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum ColoringInput {
+    Local,
+    Endpoint,
+    Uniform,
+}
+
+pub struct ContextInputs {
+    pub fibers_reader: Option<Reader>,
+    pub size_3d: UVec3,
+    pub dst_img_size: UVec2,
+    pub streamline_batch_size: usize,
+    pub white_mode: bool,
+    pub coloring: Coloring,
+}
+
+impl ContextInputs {
+    pub fn new(args: &Args, nifti_header: &NiftiHeader) -> ContextInputs {
+        let fibers_reader = args
+            .fibers
+            .as_ref()
+            .map(|path| fibers_reader(path, &nifti_header));
+
+        let coloring = match args.coloring {
+            ColoringInput::Local => Coloring::Local,
+            ColoringInput::Endpoint => Coloring::Endpoint,
+            ColoringInput::Uniform => {
+                Coloring::Uniform(Vector3::new(args.rgb[0], args.rgb[1], args.rgb[2]))
+            }
+        };
+        ContextInputs {
+            fibers_reader,
+            size_3d: get_dim(&nifti_header),
+            dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
+            streamline_batch_size: args.batch_size,
+            white_mode: args.white,
+            coloring,
+        }
+    }
+}
+
+fn get_dim(nifti_header: &NiftiHeader) -> UVec3 {
+    let dim: &[u16] = nifti_header
+        .dim()
+        .expect("The NIfTI must have consistent dimensions");
+
+    if dim.len() != 3 {
+        panic!("A 3D image is expected.")
+    }
+    uvec3(dim[0] as u32, dim[1] as u32, dim[2] as u32)
+}

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -77,7 +77,7 @@ impl ContextInputs {
         let fibers_reader = args
             .fibers
             .as_ref()
-            .map(|path| fibers_reader(path, &nifti_header));
+            .map(|path| fibers_reader(path, nifti_header));
 
         let coloring = match args.coloring {
             ColoringInput::Local => Coloring::Local,
@@ -88,7 +88,7 @@ impl ContextInputs {
         };
         ContextInputs {
             fibers_reader,
-            size_3d: get_dim(&nifti_header),
+            size_3d: get_dim(nifti_header),
             dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
             streamline_batch_size: args.batch_size,
             white_mode: args.white,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,114 +1,30 @@
-use std::{path::PathBuf, time::Instant};
+use std::time::Instant;
 
 use clap::Parser;
-use glam::{uvec2, uvec3, UVec2, UVec3};
-use nalgebra::Vector3;
-use nifti::NiftiHeader;
-use trk_io::Reader;
 
-use file::{fibers_reader, read_3d_image};
-use graphics::Coloring;
-use slicer::{ImageSlice, Slicer, View};
+use file::read_3d_image;
+use inputs::{Args, ContextInputs};
+use slicer::{ImageSlice, Slicer};
 
 mod file;
 mod graphics;
+mod inputs;
 mod slicer;
 
 type Image = image::RgbaImage;
 
-#[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
-struct Args {
-    /// Input NIfTI image
-    pub input_image: PathBuf,
-
-    /// Use a white background instead of black
-    #[arg(short, long, default_value = "false")]
-    pub white: bool,
-
-    /// Output folder to save all png
-    #[arg(short, long)]
-    pub fibers: Option<PathBuf>,
-
-    /// How many streamlines are batched per buffer
-    #[arg(short, long, default_value = "50000", requires("fibers"))]
-    pub batch_size: usize,
-
-    /// Color mode for the fibers
-    #[arg(long, default_value = "local", requires("fibers"))]
-    pub coloring: ColoringInput,
-
-    /// RGB Color used by the uniform coloring mode
-    #[arg(
-        num_args(3),
-        long,
-        required_if_eq("coloring", "uniform"),
-        value_names = &["R", "G", "B"]
-    )]
-    pub rgb: Vec<u32>,
-
-    /// Output folder to save all png
-    pub output: PathBuf,
-
-    /// Width and height of the output 2D image
-    #[arg(
-        num_args(2), 
-        long, 
-        default_values = ["800", "600"], 
-        value_names = &["WIDTH", "HEIGHT"] 
-    )]
-    pub output_size: Vec<u32>,
-
-    /// Which view(s) to use tp capture the image(s)
-    #[arg(num_args(1..7), long, default_values = ["superior", "posterior", "left"])]
-    pub views: Vec<View>,
-}
-
-#[derive(Clone, Debug, clap::ValueEnum)]
-pub enum ColoringInput {
-    Local,
-    Endpoint,
-    Uniform,
-}
-
-pub struct ContextInputs {
-    pub fibers_reader: Option<Reader>,
-    pub size_3d: UVec3,
-    pub dst_img_size: UVec2,
-    pub streamline_batch_size: usize,
-    pub white_mode: bool,
-    pub coloring: Coloring,
-}
-
 fn main() {
     let start = Instant::now();
+
     init_logger();
 
     let args = Args::parse();
+    let (nifti_header, data) = read_3d_image::<_, f32>(&args.input_image);
 
-    let (nifti_header, data) = read_3d_image::<_, f32>(args.input_image);
-    let fibers_reader = args.fibers.map(|path| fibers_reader(path, &nifti_header));
-
-    let size_3d = get_dim(&nifti_header);
-    let slicer = Slicer::from_3d(nifti_header, data, 3, &args.views, (0.3, 0.7));
-
-    let coloring = match args.coloring {
-        ColoringInput::Local => Coloring::Local,
-        ColoringInput::Endpoint => Coloring::Endpoint,
-        ColoringInput::Uniform => {
-            Coloring::Uniform(Vector3::new(args.rgb[0], args.rgb[1], args.rgb[2]))
-        }
-    };
-
-    let inputs = ContextInputs {
-        fibers_reader,
-        size_3d,
-        dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
-        streamline_batch_size: args.batch_size,
-        white_mode: args.white,
-        coloring,
-    };
+    let inputs = ContextInputs::new(&args, &nifti_header);
     let mut graphics = graphics::Context::new(inputs);
+
+    let slicer = Slicer::from_3d(nifti_header, data, 3, &args.views, (0.3, 0.7));
 
     for slice in slicer.slices {
         let image = graphics.process_slice(&slice);
@@ -120,17 +36,6 @@ fn main() {
     }
 
     log::info!("Program duration: {:?}", start.elapsed());
-}
-
-fn get_dim(nifti_header: &NiftiHeader) -> UVec3 {
-    let dim: &[u16] = nifti_header
-        .dim()
-        .expect("The NIfTI must have consistent dimensions");
-
-    if dim.len() != 3 {
-        panic!("A 3D image is expected.")
-    }
-    uvec3(dim[0] as u32, dim[1] as u32, dim[2] as u32)
 }
 
 fn init_logger() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,12 @@ use std::{path::PathBuf, time::Instant};
 
 use clap::Parser;
 use glam::{uvec2, uvec3, UVec2, UVec3};
+use nalgebra::Vector3;
 use nifti::NiftiHeader;
 use trk_io::Reader;
 
 use file::{fibers_reader, read_3d_image};
+use graphics::Coloring;
 use slicer::{ImageSlice, Slicer, View};
 
 mod file;
@@ -29,19 +31,44 @@ struct Args {
     pub fibers: Option<PathBuf>,
 
     /// How many streamlines are batched per buffer
-    #[arg(short, long, default_value = "50000")]
+    #[arg(short, long, default_value = "50000", requires("fibers"))]
     pub batch_size: usize,
+
+    /// Color mode for the fibers
+    #[arg(long, default_value = "local", requires("fibers"))]
+    pub coloring: ColoringInput,
+
+    /// RGB Color used by the uniform coloring mode
+    #[arg(
+        num_args(3),
+        long,
+        required_if_eq("coloring", "uniform"),
+        value_names = &["R", "G", "B"]
+    )]
+    pub rgb: Vec<u32>,
 
     /// Output folder to save all png
     pub output: PathBuf,
 
     /// Width and height of the output 2D image
-    #[arg(num_args(2), long, default_values = ["800", "600"])]
+    #[arg(
+        num_args(2), 
+        long, 
+        default_values = ["800", "600"], 
+        value_names = &["WIDTH", "HEIGHT"] 
+    )]
     pub output_size: Vec<u32>,
 
     /// Which view(s) to use tp capture the image(s)
     #[arg(num_args(1..7), long, default_values = ["superior", "posterior", "left"])]
     pub views: Vec<View>,
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum ColoringInput {
+    Local,
+    Endpoint,
+    Uniform,
 }
 
 pub struct ContextInputs {
@@ -50,6 +77,7 @@ pub struct ContextInputs {
     pub dst_img_size: UVec2,
     pub streamline_batch_size: usize,
     pub white_mode: bool,
+    pub coloring: Coloring,
 }
 
 fn main() {
@@ -64,12 +92,21 @@ fn main() {
     let size_3d = get_dim(&nifti_header);
     let slicer = Slicer::from_3d(nifti_header, data, 3, &args.views, (0.3, 0.7));
 
+    let coloring = match args.coloring {
+        ColoringInput::Local => Coloring::Local,
+        ColoringInput::Endpoint => Coloring::Endpoint,
+        ColoringInput::Uniform => {
+            Coloring::Uniform(Vector3::new(args.rgb[0], args.rgb[1], args.rgb[2]))
+        }
+    };
+
     let inputs = ContextInputs {
         fibers_reader,
         size_3d,
         dst_img_size: uvec2(args.output_size[0], args.output_size[1]),
         streamline_batch_size: args.batch_size,
         white_mode: args.white,
+        coloring,
     };
     let mut graphics = graphics::Context::new(inputs);
 


### PR DESCRIPTION
- Added new command-line options `--coloring` and `--rgb`.
- Added endpoint and uniform coloring. The new code is mostly contained inside `coloring.rs`.

![sheet](https://github.com/user-attachments/assets/d8a04acd-c290-480f-a189-4cf6935c0a7d)
